### PR TITLE
Main menu updates

### DIFF
--- a/src/components/SetAssetsPathForm.tsx
+++ b/src/components/SetAssetsPathForm.tsx
@@ -6,6 +6,7 @@ import { CACHE_CLIENT } from "../cache/cacheClient";
 
 export class SetAssetsPathForm extends React.Component<{
     setRootAssetsPathHandler: any
+    clearSelectedOptionHandler: () => void
 }, {
     input: string
     inputIsValid: boolean
@@ -18,13 +19,26 @@ export class SetAssetsPathForm extends React.Component<{
         }
     }
 
+    submitHandler(value: string) {
+        if(value === `q`) {
+            this.props.clearSelectedOptionHandler()
+        } else {
+            this.props.setRootAssetsPathHandler(this.state.input)
+            generateRawData({ path: this.state.input, setRawDataHandler: CACHE_CLIENT.setRawData })
+        }
+        
+    }
+
     setInputHandler = (input: any) => {
         this.setState({
             ...this.state,
             input
         })
         var lastPart = this.state.input.split("/").pop()
-        if (lastPart === 'assets' && validatesAssetsDirectory({ path: input })) {
+        if ((
+            lastPart === 'assets' && validatesAssetsDirectory({ path: input })) || 
+            input === `q`
+        ) {
             this.setState({
                 ...this.state,
                 inputIsValid: true,
@@ -46,10 +60,7 @@ export class SetAssetsPathForm extends React.Component<{
                 <Box justifyContent="flex-start" marginLeft={2}>
                     <Text>➡️  Enter path to 'assets' directory:</Text>
                     {this.state.inputIsValid ? <Text> ✔️  </Text> : <Text> ✖️  </Text> }
-                    <TextInput key="" value={this.state.input} onChange={this.setInputHandler} onSubmit={() => {
-                        this.props.setRootAssetsPathHandler(this.state.input)
-                        generateRawData({ path: this.state.input, setRawDataHandler: CACHE_CLIENT.setRawData })
-                    }}/>
+                    <TextInput key="" value={this.state.input} onChange={this.setInputHandler} onSubmit={(value: string) => this.submitHandler(value)}/>
                 </Box>
                 <Box marginLeft={1}>
                     {(!this.state.inputIsValid && this.state.input.length !== 0) ? 


### PR DESCRIPTION
# Description

Adds some minor updates to the main menu

## Changelog
1. `SetAssetsPathForm` is now "quittable" by entering `q` and submitting it (brings the user back to the main menu)
2. Initialize some state values from the cache
3. Make the menu options change depending on the values in the cache
4. User no longer _has_ to enter the assets path; if they have already provided one, it will be displayed without the user needing to do anything and they can proceed from there