### PR TITLE
Display formatted parsed data and improve main menu option logic

### DIFF
--- a/docs/Zombie_Process.md
+++ b/docs/Zombie_Process.md
@@ -1,0 +1,15 @@
+# Zombie processes
+
+While developing on `minecraft-assets-reader`, it's possible to hit certain types of crashes where the app can't be exited. In this
+case,  you'll likely end up with an `ngrok` ["zombie process"](https://en.wikipedia.org/wiki/Zombie_process). 
+
+**Zombie processes cannot be directly stopped or killed - you must kill the parent process to stop it**.
+
+## Suggestions to fix it
+
+### General
+1. Track down the parent process that's running it and kill _that_ process
+
+### `minecraft-assets-reader`-specific
+1. Close all terminal windows > wait several seconds > reopen the terminal
+    * Open the System Monitor > search for `ngrok` > Select "End/Kill process" (if it's still there) > continue testing!

--- a/src/components/InspectParsedData.tsx
+++ b/src/components/InspectParsedData.tsx
@@ -1,0 +1,55 @@
+import { Box, Text } from "ink"
+import React from "react"
+import { CACHE } from "../cache/cacheClient"
+import { BlockPage, ParsedData } from "../types"
+import { NamespaceParsedBlockData } from "./NamespaceParsedData"
+
+export class InspectParsedData extends React.Component<
+{
+    // props
+    clearSelectedOptionHandler: () => void
+},
+{
+    // state
+    parsedData: ParsedData
+}> {
+
+    constructor(props: any) {
+        super(props)
+        this.state = {
+            parsedData: {}
+        }
+    }
+
+    componentDidMount() {
+        CACHE.getParsedDataFromCache().then(parsedData => this.setState( prevState => ({
+            ...prevState,
+            parsedData,
+        })))
+    }
+
+    render() {
+        
+        const {
+            parsedData
+        } = this.state
+
+        // Array of namespaces in the parsed data
+        const parsedDataNamespaces = Object.keys(parsedData)
+
+        return (
+            <>
+            {(parsedDataNamespaces.length > 0) ?  
+                parsedDataNamespaces.map(namespace => (
+                    <Box key={namespace} flexDirection="column">
+                        <Text color="magentaBright" bold>{namespace}</Text>
+                        {parsedData[namespace].blockPages ? 
+                            parsedData[namespace].blockPages!.map((blockPage: BlockPage) => <NamespaceParsedBlockData blockPage={blockPage} />)
+                        : null }
+                    </Box>
+                ))
+            : <Text>NO DATA</Text> }
+        </>
+        )
+    }
+}

--- a/src/components/NamespaceParsedData.tsx
+++ b/src/components/NamespaceParsedData.tsx
@@ -1,0 +1,35 @@
+import { Box, Text } from "ink"
+import React from "react"
+import { BlockPage } from "../types"
+import { ArrayTextBlock } from "./shared/ArrayTextBlock"
+import { Tab } from "./shared/Tab"
+
+
+
+export class NamespaceParsedBlockData extends React.Component<
+{
+    // props
+    blockPage: BlockPage
+}, 
+{
+    // state
+}> {
+    render() {
+
+        const {
+            title,
+            models,
+            variantModelNames,
+            textureNames
+        } = this.props.blockPage
+
+        return (
+            <>
+                <Text bold><Tab count={2}/>{title}</Text>
+                <ArrayTextBlock label={"Model file names"} nestingDepth={2} array={models}/>
+                <ArrayTextBlock label={"Variant model file names"} nestingDepth={2} array={variantModelNames ? variantModelNames : []}/>
+                <ArrayTextBlock label={"Texture file names"} nestingDepth={2} array={textureNames}/>
+            </>
+        )
+    }
+}

--- a/src/components/shared/ArrayTextBlock.tsx
+++ b/src/components/shared/ArrayTextBlock.tsx
@@ -1,0 +1,17 @@
+import { Box, Text } from "ink"
+import React from "react"
+import { Tab } from "./Tab"
+
+export const ArrayTextBlock = ({label, array }: {label: string, nestingDepth: number, array: string[]}) => {
+    return (
+        <>
+            <Text><Tab count={3}/>{label}: {array.map((val, index) => {
+                let str = val
+                if (index !== (array.length - 1)){
+                    str += `, `
+                }
+                return str
+            })}</Text>
+        </>
+    )
+}

--- a/src/components/shared/Tab.tsx
+++ b/src/components/shared/Tab.tsx
@@ -1,0 +1,15 @@
+import { Text } from "ink"
+import { times } from "lodash"
+import React from "react"
+
+/**
+ * Helper component to make it easier to implement "tabs" in the terminal
+ * output. We use 2 spaces instead of `\t` simply because the spacing is far too wide,
+ * otherwise
+ * 
+ * @param param0 
+ * @returns 
+ */
+export const Tab = ({ count }: { count: number }) => <Text>{
+        times(count, () => `  `)
+    }</Text>


### PR DESCRIPTION
# Description

Display cached parsed data and make main menu option population logic more-dependent on the cache and less procedural

## Changelog
1. No longer set any "default" main menu options (menu is technically empty by default, but the options render quickly enough to not notice it)
2. Improve logic around loading cache-linked state values
3. Clean up the `CLIApp` class for better readability/adhere to DRY
4. Add logic to prevent duplicate menu options
5. Implement component to view parsed data in formatted view