### PR TITLE
Fix export data logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
 out
+generated
 .env
 
-export

--- a/src/export/exporter.ts
+++ b/src/export/exporter.ts
@@ -1,0 +1,65 @@
+import { CACHE } from "../cache/cacheClient";
+import mkdirp from "mkdirp"
+import { ParsedData } from "../types";
+import { writeFileSync } from "fs";
+
+const DEFAULT_WRITE_PATH = `./generated/`
+
+export class Exporter {
+
+    /**
+     * Write the cached parsed data to the local file system
+     * 
+     * @param args 
+     */
+    async exportParsedDataToLocalFilesystem(args: {
+        path?: string,
+        createSeparatePageFiles?: boolean
+    }) {
+        const parsedData = await CACHE.getParsedDataFromCache()
+        let baseWritePath = `${DEFAULT_WRITE_PATH}/${new Date().toISOString()}`
+        // If the user provided a write path, use that instead of the default write path
+        if (args.path) {
+            baseWritePath = args.path!
+        }
+        // Create the data export directory
+        await mkdirp(baseWritePath)
+
+        if (!!args.createSeparatePageFiles) {
+            this.writePageContentAsSeparateJSONFiles({
+                parsedData,
+                baseWritePath,
+            })
+        } else {
+            this.writePageContentAsJSONArrayFiles({
+                parsedData,
+                baseWritePath,
+            })
+        }
+        return true
+    }
+
+    private writePageContentAsJSONArrayFiles(args: {
+        parsedData: ParsedData
+        baseWritePath: string,
+    }) {
+        const namespaces = Object.keys(args.parsedData)
+        namespaces.forEach(namespace => {
+            const {
+                blockPages,
+                itemPages
+            } = args.parsedData[namespace]
+
+            writeFileSync(`${args.baseWritePath}/block-pages.json`, JSON.stringify(blockPages))
+            writeFileSync(`${args.baseWritePath}/item-pages.json`, JSON.stringify(itemPages))
+        })
+    }
+
+    private writePageContentAsSeparateJSONFiles(args: {
+        parsedData: ParsedData
+        baseWritePath: string,
+    }) {
+        // TODO: Larah - complete this method :)
+    }
+
+}


### PR DESCRIPTION
In #8 I inadvertently ignored the `export` directory (as the generated folder was originally named); I didn't think about it, but by adding `export` to the `.gitignore` file, I accidentally made it ignore the core logic for the export functionality since that was also in a directory named "export" (just nested in `src`) :facepalm: 

This PR corrects my egregious error :+1: 

## Changelog
1. Re-implement basic export logic
    * `Exporter` class
    * Use `exportParsedDataToLocalFilesystem` as the core method for the export logic
    * `writePageContentAsJSONArrayFiles` simply writes the data stored in the `parsedData` object without separating the arrays into separate files for each JSON object
2. Update `.gitignore` so that it ignores the `generated` directory - only contains generated data specific to the imported minecraft data; nothing to do with the codebase (except for testing that the data looks like you expect it to)