### PR TITLE
Fix block content generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "reset": "rm -rf out/ && npm run build",
+    "reset": "rm -rf out/ generated/ && npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/src/cache/appCache.ts
+++ b/src/cache/appCache.ts
@@ -116,17 +116,18 @@ export class AppCache {
         // console.log(`SET CACHED RAW DATA RESPONSE: `, response)
     }
 
-    // TODO: Figure out why the logging here only displays on the second run (something with the async stuff, I'm sure)
+    /**
+     * Update the cached parsed data with the given parsed data object
+     * 
+     * This method handles merging the data from the "old" parsed data
+     * with the updated one, so that data is not overwritten and kept
+     * up-to-date.
+     * 
+     * @param updatedParsedDataObject 
+     * @returns 
+     */
     async setCachedParsedData(updatedParsedDataObject: ParsedData) {
         const cachedParsedData = await this.getParsedDataFromCache()
-
-        Object.keys(cachedParsedData).forEach(namespace => {
-            const blockPageCount = cachedParsedData[namespace].blockPages!.length
-            const itemPageCount = cachedParsedData[namespace].itemPages!.length
-
-            console.log(`BLOCK PAGE COUNT: `, blockPageCount)
-            console.log(`ITEM PAGE COUNT: `, itemPageCount)
-        })
 
         const updatedParsedData = {
             ...cachedParsedData,
@@ -137,7 +138,6 @@ export class AppCache {
             KEYS.PARSED_DATA,
             updatedParsedDataBase64
         )
-        // console.log(`SET CACHED PARSED DATA RESPONSE: `, response)
         return response
     }
 

--- a/src/cache/cacheClient.ts
+++ b/src/cache/cacheClient.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "fs"
 import { filter, indexOf } from "lodash"
 import { loadTexturesFromBlockstateVariants, loadTexturesFromElements, loadTexturesFromTextureField } from "../contentGenerator"
+import { MinecraftAssetReader } from "../minecraft/minecraftAssetReader"
 import { readBlockstates, readModels, readTextures } from "../minecraft/readBlockData"
 import { BlockstateMultipartCase } from "../minecraft/types"
 import { BlockPage, ItemPage, ParsedData, RawAssetData } from "../types"
@@ -13,41 +14,10 @@ export const CACHE = new AppCache()
  */
 class CacheClient {
 
-    loadBlockTexturesForNamespace(args: { namespace: string, rawData: RawAssetData, parsedData: ParsedData, rootAssetsPath: string }) {
+    minecraftAssetReader: MinecraftAssetReader
 
-        const { 
-            namespace,
-            rawData,
-            parsedData,
-            rootAssetsPath
-         } = args
-
-         let localParsedData = {
-             ...parsedData,
-         } as ParsedData
-
-        // console.log(`Pages to import textures for: `, parsedData![args.namespace].blockPages!.length)
-        parsedData![args.namespace].blockPages!.forEach(blockPage => {
-            // console.log(`Loading textures for '${blockPage.title}' in namespace '${args.namespace}'`)
-            blockPage.textureNames.map(blockTextureName => {
-                const indexOfBlockPage = indexOf(parsedData[args.namespace].blockPages, blockPage)
-                // console.log(`INDEX OF TARGET BLOCK PAGE: `, indexOfBlockPage)
-                const imageBuffer = readFileSync(`${rootAssetsPath}/${args.namespace}/textures/blocks/${blockTextureName}.png`)
-
-                // Create a new BlockPage from the existing data and the new data
-                let updatedBlock = parsedData![args.namespace].blockPages![indexOfBlockPage]
-                updatedBlock.textures[blockTextureName] = imageBuffer.toString("base64")
-
-
-                // Remove the stale entry
-                localParsedData[namespace].blockPages!.splice(indexOfBlockPage, 1)
-                // Add the updated entry
-                localParsedData[namespace].blockPages!.push(updatedBlock)
-            })
-            // console.log(`Texture loaded for '${blockPage.title}'!`)
-        })
-
-        return localParsedData
+    constructor() {
+        this.minecraftAssetReader = new MinecraftAssetReader()
     }
 
     async setRootAssetsPath(rootAssetsPath: string) {
@@ -89,223 +59,13 @@ class CacheClient {
             }
         })
         await CACHE.setCachedRawData(rawData)
-        const rawDataUpdated = await CACHE.getRawDataFromCache()
     }
 
     /**
      * Parses imported raw data into base site page content
      */
     async parseImportedData() {
-        const rawData = await CACHE.getRawDataFromCache()
-        const assetsPath = await CACHE.getRootAssetsPath()
-        let localParsedData = {} as ParsedData
-        Object.keys(rawData).forEach(namespace => {
-
-            const blockPagesFromBlockstates = this.generatePageDataFromBlockstatesForNamespace({
-                namespace,
-                assetsPath: assetsPath!,
-                rawData,
-            })
-
-            localParsedData = {
-                ...localParsedData,
-                [namespace]: {
-                    blockPages: blockPagesFromBlockstates,
-                    itemPages: []
-                }
-            }
-
-            const parsedDataNoTextureBufferStrings = this.addTextureNamesToBlockPages({
-                namespace,
-                assetsPath: assetsPath!,
-                rawData,
-                parsedData: localParsedData
-            })
-
-            localParsedData = this.loadBlockTexturesForNamespace({
-                namespace,
-                rawData,
-                parsedData: parsedDataNoTextureBufferStrings,
-                rootAssetsPath: assetsPath!
-            })
-        })
-        await CACHE.setCachedParsedData(localParsedData)
-    }
-
-    /**
-     * Generate page data for Blocks from the blockstates in the given namespace's raw data
-     * 
-     * @param args 
-     */
-    generatePageDataFromBlockstatesForNamespace(args: { namespace: string, assetsPath: string, rawData: RawAssetData }) {
-        const blockNamesInferredFromBlockstates = Object.keys(args.rawData[args.namespace].blockstates)
-        const blockPages = [] as BlockPage[]
-        blockNamesInferredFromBlockstates.forEach( blockName => {
-            // console.log(`Generating page data for block '${blockName}' in namespace '${args.namespace}'`)
-            let variantModelNames = [] as string[]
-            let multipartCases = [] as BlockstateMultipartCase[]
-            const blockstateDataForBlock = args.rawData[args.namespace].blockstates[blockName]
-            if (blockstateDataForBlock.variants!) {
-                // This blockstates file uses variants
-                const variants = blockstateDataForBlock.variants
-                Object.keys(variants).forEach(key => {
-                    if (key && !variantModelNames.includes(variants[key].model)) {
-                        variantModelNames.push(variants[key].model)
-                    }
-                })
-            } else if (blockstateDataForBlock.multipart!) {
-                // This blockstates file uses multipart
-                multipartCases = blockstateDataForBlock.multipart
-            }
-            let textureNamesForBlockstate = [] as any[]
-            try {
-                textureNamesForBlockstate = loadTexturesFromBlockstateVariants({
-                    namespace: args.namespace,
-                    assetsPath: args.assetsPath!,
-                    blockName,
-                    rawData: args.rawData
-                })
-            } catch (e) {
-                // TODO: Make this log event a "warn" level
-                /**
-                 * N.B.
-                 * 
-                 * It is possible, and acceptable, for the variants field to be undefined. This happens when the blockstates
-                 * file uses a multipart field, in which case, variants *can't* be defined (they are mutually-exclusive).
-                 * 
-                 * When variants is undefined, we simply log what likely happened, then move on.
-                 */
-                console.warn(`Encountered blockstate file with undefined variants - skipping texture loading for '${blockName}'`)
-            }
-            blockPages.push({
-                title: blockName,
-                models: [blockName],
-                textureNames: textureNamesForBlockstate,
-                textures: {},
-                multipartCases,
-            })
-        })
-        return blockPages
-    }
-
-    /**
-     * Adds texture names to block pages
-     * 
-     * If a model file name is encountered and it's not related to an existing Block page, then we know
-     * the given model file is not one that was defined in blockstates. In this case, we need to create
-     * a new block page _and_ add the texture names to it. This is the only exception. For all other blocks,
-     * the texture name(s) is/are added to the corresponding block page
-     * 
-     * @param args 
-     * @returns A modified copy of the parsedData object passed to this method; e.g., the "updated parsedData" object
-     */
-    addTextureNamesToBlockPages(args: 
-        {
-            namespace: string,
-            assetsPath: string,
-            rawData: RawAssetData,
-            parsedData: ParsedData
-        }) 
-    {
-
-        const { 
-            namespace,
-            assetsPath,
-            rawData,
-            parsedData
-         } = args
-
-         // Used to store modifications to parsed data object, returned to be used as the updated version
-         let localParsedData = {
-             ...parsedData
-         } as ParsedData
-    
-        /**
-         * The list of model file names stored in the raw data - each model file will contain one, or many
-         * textures, depending on the file setup
-         */
-        const blockModelFileNames = Object.keys(rawData[namespace].model.block)
-        blockModelFileNames.map(blockModelFileName => {
-            /**
-             * The complete list of textures for the current block
-             * 
-             * This contains a list of the texture names after they've been loaded from the model's textures
-             * or elements field; if textures is defined, elements will be undefined, and vice versa.
-             */
-            let texturesForBlockModel = [] as any[]
-            try {
-                if (rawData[namespace].model.block[blockModelFileName].textures!) {
-                    texturesForBlockModel = loadTexturesFromTextureField({ namespace: namespace, blockModelFileName, rawData: rawData })
-                } else if (rawData[namespace].model.block[blockModelFileName].elements!) {
-                    // This block model file doesn't have a textures field, but uses the "elements" field instead (which has nested textures)
-                    texturesForBlockModel = loadTexturesFromElements({ namespace: namespace, blockModelFileName })
-                }
-            } catch (e) {
-                console.warn(`Encountered model file with undefined textures field - this is not necessarily a problem - skipping loading textures for model file '${blockModelFileName}'`)
-            }
-            /**
-             * The list of maching blocks for the current blockModelName
-             */
-            const blockPageMatchesForTextureFileName = filter(parsedData[namespace].blockPages , page => {
-                /**
-                 *  Wheat model file names don't follow convention and have numbers appended to the end of the file name 
-                 * (they will never match exactly with the base model and need to be handled specially)
-                 */
-                if (blockModelFileName.includes("wheat")) {
-                    return blockModelFileName.includes(page.title)
-                } else {
-                    return blockModelFileName === page.title
-                }
-            })
-            if (blockPageMatchesForTextureFileName.length === 0) {
-                // A new block definition was encountered (e.g., no matches found)
-                localParsedData[namespace].blockPages!.push({
-                    title: blockModelFileName,
-                    textures: {},
-                    textureNames: texturesForBlockModel,
-                    multipartCases: [],
-                    models: [],
-                })
-            } else if (blockPageMatchesForTextureFileName.length === 1) {
-                let indexOfBlockPage: number
-                // Only one match was found for the current block model file name - index is 0
-                indexOfBlockPage = indexOf(parsedData[namespace].blockPages, blockPageMatchesForTextureFileName[0])
-
-                // Create a new BlockPage from the existing data and the new data
-                let updatedBlock = parsedData[namespace].blockPages![indexOfBlockPage]
-                // console.log(`UPDATED BLOCK: `, updatedBlock)
-                updatedBlock.textureNames = [
-                    ...updatedBlock.textureNames,
-                    ...texturesForBlockModel,
-                ]
-
-                // Remove the stale entry
-                localParsedData[namespace].blockPages!.splice(indexOfBlockPage, 1)
-                // Add the updated entry
-                localParsedData[namespace].blockPages!.push(updatedBlock)
-            } else {
-                // Multiple matching block pages were found, add the block model definition to each of them
-                blockPageMatchesForTextureFileName.forEach((_, index) => {
-                    let indexOfBlockPage: number
-                    // Only one match was found for the current block model file name - index is 0
-                    indexOfBlockPage = indexOf(parsedData[namespace].blockPages, blockPageMatchesForTextureFileName[index])
-
-                    // Create a new BlockPage from the existing data and the new data
-                    let updatedBlock = parsedData[namespace].blockPages![indexOfBlockPage]
-                    // console.log(`UPDATED BLOCK: `, updatedBlock)
-                    updatedBlock.textureNames = [
-                        ...updatedBlock.textureNames,
-                        ...texturesForBlockModel,
-                    ]
-
-                    // Remove the stale entry
-                    localParsedData[namespace].blockPages!.splice(indexOfBlockPage, 1)
-                    // Add the updated entry
-                    localParsedData[namespace].blockPages!.push(updatedBlock)
-                })
-            }
-        })
-        return localParsedData
+        await this.minecraftAssetReader.parseRawData()
     }
 
 }

--- a/src/components/NamespaceParsedData.tsx
+++ b/src/components/NamespaceParsedData.tsx
@@ -21,16 +21,12 @@ export class NamespaceParsedBlockData extends React.Component<
 
         const {
             title,
-            models,
-            variantModelNames,
             textureNames
         } = this.props.blockPage
 
         return (
             <>
                 <Text bold><Tab count={2}/>{title}</Text>
-                <ArrayTextBlock label={"Model file names"} nestingDepth={2} array={models}/>
-                <ArrayTextBlock label={"Variant model file names"} nestingDepth={2} array={variantModelNames ? variantModelNames : []}/>
                 <ArrayTextBlock label={"Texture file names"} nestingDepth={2} array={textureNames}/>
             </>
         )

--- a/src/minecraft/minecraftAssetReader.ts
+++ b/src/minecraft/minecraftAssetReader.ts
@@ -1,0 +1,111 @@
+import { readFileSync } from "fs";
+import { CACHE } from "../cache/cacheClient";
+import { ParsedData } from "../types";
+import { BlockModelData } from "./types";
+
+/**
+ * Defines the operations we use to format the raw data into 
+ * parsed page content
+ * 
+ * This class contains the methods that were formerly in the contentGenerator
+ * and readBlockData files.
+ */
+export class MinecraftAssetReader {
+
+    // TODO: Find way to group related blocks (e.g., planks, bark, logs)
+    /**
+     * Controlling method to handle the entire "parse data" operation
+     */
+    async parseRawData() {
+        await this.parseModelData()
+        await this.parseTextures()
+    }
+
+    /**
+     * Helper method to load texture names for the given block model.
+     * 
+     * @param args 
+     * @returns 
+     */
+    private getTextureNamesFromRawBlockData(args: { blockData: BlockModelData }) {
+        const { blockData } = args
+        const textureNameArray = [] as string[]
+
+        if (blockData.textures) {
+            Object.keys(blockData.textures).forEach(key => {
+                const textureName = blockData.textures![key]!
+                if (!textureNameArray.includes(textureName)) {
+                    textureNameArray.push(textureName)
+                }
+            })
+        }
+
+        if (blockData.elements) {
+            blockData.elements.forEach(element => {
+                Object.keys(element.faces).forEach(key => {
+                    const textureName = element.faces[key].texture
+                    if (!textureNameArray.includes(textureName)) {
+                        textureNameArray.push(textureName)
+                    }
+                })
+            })
+        }
+
+        return textureNameArray
+    }
+
+    private async parseModelData() {
+        const newParsedData = {} as ParsedData
+        const rawData = await CACHE.getRawDataFromCache()
+        const namespaces = Object.keys(rawData)
+        namespaces.forEach(namespace => {
+
+            // Init the namespace fields
+            if (!newParsedData[namespace]) {
+                newParsedData[namespace] = {
+                    blockPages: [],
+                    itemPages: []
+                }
+            }
+
+            const {
+                block,
+                item
+            } = rawData[namespace].model
+
+            const blockModelNames = Object.keys(block)
+            blockModelNames.forEach(name => {
+                newParsedData[namespace].blockPages?.push({
+                    title: name,
+                    description: ``,
+                    textureNames: this.getTextureNamesFromRawBlockData({ blockData: block[name] }),
+                    textures: {}
+                })
+            })
+        })
+        await CACHE.setCachedParsedData(newParsedData)
+    }
+
+    /**
+     * Helper method to load the texture base64 data for all of the imported pages
+     */
+    private async parseTextures() {
+        const parsedData = await CACHE.getParsedDataFromCache()
+        const assetsPath = await CACHE.getRootAssetsPath()
+        const namespaces = Object.keys(parsedData)
+        namespaces.forEach(namespace => {
+            // Load block page textures
+            parsedData[namespace].blockPages?.forEach(blockPage => {
+                blockPage.textureNames.forEach(textureName => {
+                    if (!textureName.includes(`#`)) {
+                        const path = `${assetsPath}/${namespace}/textures/${textureName}.png`
+                        const buffer = readFileSync(path)
+                        blockPage.textures[textureName] = buffer.toString(`base64`)
+                    }
+                })
+            })
+        })
+        await CACHE.setCachedParsedData(parsedData)
+    }
+
+}

--- a/src/prompts/contentful/collectOrganizationId.ts
+++ b/src/prompts/contentful/collectOrganizationId.ts
@@ -1,6 +1,6 @@
 import inquirer from "inquirer"
 import open from "open"
-import { createSiteDataPrompt } from "./createSiteData"
+// import { createSiteDataPrompt } from "./createSiteData"
 
 export const collectOrganizationId = (
     { 
@@ -22,4 +22,4 @@ export const collectOrganizationId = (
     open(`https://be.contentful.com/oauth/authorize?response_type=token&client_id=${clientId}&redirect_uri=${redirect}&scope=content_management_manage`)
     return answers
 })
-.then(answers => createSiteDataPrompt({ organizationId: answers.organizationId }))
+// .then(answers => createSiteDataPrompt({ organizationId: answers.organizationId }))

--- a/src/prompts/contentful/createSiteData.ts
+++ b/src/prompts/contentful/createSiteData.ts
@@ -11,142 +11,142 @@ async function avoidRateLimit() {
     await sleep(250)
 }
 
-export const createSiteDataPrompt = ({ organizationId } : { organizationId: string } ) => 
-inquirer.prompt([
-    {
-        type: 'input',
-        name: 'spaceName',
-        message: "Enter a name for your site's data collection (called a 'Space' in Contentful) - for example, your mod's name:",
-    },
-])
-.then(answers => createSpace({
-    spaceName: answers.spaceName,
-    orgId: organizationId,
-    defaultLocale: `en`
-}))
-.then(resJson => {
-    console.log(`RESPONSE JSON: `, resJson)
-    // When the contentful API hits an error, it doesn't throw, but returns a valid response saying what went wrong - need to handle this manually
-    if (resJson.sys.type === `Error`) {
-        // TODO: When we hit this, we should let the user opt to try another provider that we support - for now, just stop the app
-        throw new Error(`You've hit your space limit for your account - either upgrade your subscription, or delete an existing space that you no longer need.`)
-    }
-    setSpaceId({
-        id: resJson.sys.id
-    })
-})
-.then(() => avoidRateLimit())
-.then(() => {
-    return createContentType({
-        typeName: "Block",
-        fields: [
-            {
-                id: `title`,
-                name: `Title`,
-                required: true,
-                localized: false,   // TODO: What should this be?
-                type: FIELD_TYPE.SYMBOL
-            },
-            {
-                id: `icon`,
-                name: `Icon`,
-                required: false,
-                localized: false,
-                linkType: LINK_TYPE.ASSET,
-                type: FIELD_TYPE.LINK
-            },
-            {
-                id: `models`,
-                name: `Model File Names`,
-                required: false,
-                localized: false,
-                type: FIELD_TYPE.ARRAY
-            },
-            {
-                id: `description`,
-                name: `Description`,
-                required: false,
-                localized: false,
-                type: FIELD_TYPE.TEXT
-            },
-            {
-                id: `variantModels`,
-                name: `Variant Model File Names`,
-                required: false,
-                localized: false,
-                type: FIELD_TYPE.ARRAY
-            },
-            {
-                id: `textures`,
-                name: `Textures`,
-                required: false,
-                localized: false,
-                type: FIELD_TYPE.ARRAY
-            },
-            {
-                id: `multipartCases`,
-                name: `Multipart Cases`,
-                required: false,
-                localized: false,
-                type: FIELD_TYPE.ARRAY
-            },
-        ]
-    })
-})
-.then(resJson => {
-    console.log(`RES JSON: `, resJson)
-    if (resJson.sys.type === `Error`) {
-        var string = `MESSAGES:\n`
-        resJson.details.errors.forEach((err: any) => {
-            console.log(`ERROR: `, err)
-            string += `\tUnable to create field '${err.value}' - ${err.details}`
-            if (err.expected) {
+// export const createSiteDataPrompt = ({ organizationId } : { organizationId: string } ) => 
+// inquirer.prompt([
+//     {
+//         type: 'input',
+//         name: 'spaceName',
+//         message: "Enter a name for your site's data collection (called a 'Space' in Contentful) - for example, your mod's name:",
+//     },
+// ])
+// .then(answers => createSpace({
+//     spaceName: answers.spaceName,
+//     orgId: organizationId,
+//     defaultLocale: `en`
+// }))
+// .then(resJson => {
+//     console.log(`RESPONSE JSON: `, resJson)
+//     // When the contentful API hits an error, it doesn't throw, but returns a valid response saying what went wrong - need to handle this manually
+//     if (resJson.sys.type === `Error`) {
+//         // TODO: When we hit this, we should let the user opt to try another provider that we support - for now, just stop the app
+//         throw new Error(`You've hit your space limit for your account - either upgrade your subscription, or delete an existing space that you no longer need.`)
+//     }
+//     setSpaceId({
+//         id: resJson.sys.id
+//     })
+// })
+// .then(() => avoidRateLimit())
+// .then(() => {
+//     return createContentType({
+//         typeName: "Block",
+//         fields: [
+//             {
+//                 id: `title`,
+//                 name: `Title`,
+//                 required: true,
+//                 localized: false,   // TODO: What should this be?
+//                 type: FIELD_TYPE.SYMBOL
+//             },
+//             {
+//                 id: `icon`,
+//                 name: `Icon`,
+//                 required: false,
+//                 localized: false,
+//                 linkType: LINK_TYPE.ASSET,
+//                 type: FIELD_TYPE.LINK
+//             },
+//             {
+//                 id: `models`,
+//                 name: `Model File Names`,
+//                 required: false,
+//                 localized: false,
+//                 type: FIELD_TYPE.ARRAY
+//             },
+//             {
+//                 id: `description`,
+//                 name: `Description`,
+//                 required: false,
+//                 localized: false,
+//                 type: FIELD_TYPE.TEXT
+//             },
+//             {
+//                 id: `variantModels`,
+//                 name: `Variant Model File Names`,
+//                 required: false,
+//                 localized: false,
+//                 type: FIELD_TYPE.ARRAY
+//             },
+//             {
+//                 id: `textures`,
+//                 name: `Textures`,
+//                 required: false,
+//                 localized: false,
+//                 type: FIELD_TYPE.ARRAY
+//             },
+//             {
+//                 id: `multipartCases`,
+//                 name: `Multipart Cases`,
+//                 required: false,
+//                 localized: false,
+//                 type: FIELD_TYPE.ARRAY
+//             },
+//         ]
+//     })
+// })
+// .then(resJson => {
+//     console.log(`RES JSON: `, resJson)
+//     if (resJson.sys.type === `Error`) {
+//         var string = `MESSAGES:\n`
+//         resJson.details.errors.forEach((err: any) => {
+//             console.log(`ERROR: `, err)
+//             string += `\tUnable to create field '${err.value}' - ${err.details}`
+//             if (err.expected) {
 
-            }
-        })
-        throw new Error(string)
-    }
-    // We've gotten the BlockModel ID back from contentful - we can now activate it
-    setBlockModelId({
-        id: resJson.sys.id
-    })
-})
-.then(() => avoidRateLimit())
-.then(() => {
-    return publishContentType({
-        contentTypeId: getBlockModelId()
-    })
-})
-.then(() => avoidRateLimit())
-.then(() => {
-     // Long-running operation
-    const blockPagePromises = BLOCK_PAGES.map(blockPage => {
-        return createContentTypeEntry({
-            contentTypeId: getBlockModelId(),
-            fields: {
-                title: {
-                    "en-US": blockPage.title
-                },
-                // TODO: How do we set non-string fields? Contentful's docs are ass
-                models: blockPage.models.map(modelName => {
-                    return {
-                        "en-US": modelName
-                    }
-                }),
-                variantModels: blockPage.variantModelNames ? blockPage.variantModelNames!.map(variantModelName => {
-                    return {
-                        "en-US": variantModelName
-                    }
-                }) : [],
-            }
-        })
-        .then(resJson => {
-            console.log(`Create Content Type response: `, resJson)
-            return avoidRateLimit()
-        })
-    })
-    blockPagePromises.reduce((p, fn) => p.then(() => fn), Promise.resolve())
-})
-.catch(err => {
-    console.error(`Unable to create site data in Contentful: ${err.message}`)
-})
+//             }
+//         })
+//         throw new Error(string)
+//     }
+//     // We've gotten the BlockModel ID back from contentful - we can now activate it
+//     setBlockModelId({
+//         id: resJson.sys.id
+//     })
+// })
+// .then(() => avoidRateLimit())
+// .then(() => {
+//     return publishContentType({
+//         contentTypeId: getBlockModelId()
+//     })
+// })
+// .then(() => avoidRateLimit())
+// .then(() => {
+//      // Long-running operation
+//     const blockPagePromises = BLOCK_PAGES.map(blockPage => {
+//         return createContentTypeEntry({
+//             contentTypeId: getBlockModelId(),
+//             fields: {
+//                 title: {
+//                     "en-US": blockPage.title
+//                 },
+//                 // TODO: How do we set non-string fields? Contentful's docs are ass
+//                 models: blockPage.models.map(modelName => {
+//                     return {
+//                         "en-US": modelName
+//                     }
+//                 }),
+//                 variantModels: blockPage.variantModelNames ? blockPage.variantModelNames!.map(variantModelName => {
+//                     return {
+//                         "en-US": variantModelName
+//                     }
+//                 }) : [],
+//             }
+//         })
+//         .then(resJson => {
+//             console.log(`Create Content Type response: `, resJson)
+//             return avoidRateLimit()
+//         })
+//     })
+//     blockPagePromises.reduce((p, fn) => p.then(() => fn), Promise.resolve())
+// })
+// .catch(err => {
+//     console.error(`Unable to create site data in Contentful: ${err.message}`)
+// })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 // This file only contains types that are used when uploading data to a CMS
 
-import { BlockBlockstateData, BlockModelData, BlockstateMultipartCase, ItemModelData } from "./minecraft/types"
+import { BlockBlockstateData, BlockModelData, ItemModelData } from "./minecraft/types"
 
 // Defines the Int type
 export type Int = number & { __int__: void };
@@ -82,25 +82,13 @@ export type BlockPage = {
      */
     title: string
     /**
-     * The image to upload as the block pages main image
-     */
-    icon?: Buffer
-    /**
-     * A list of model file names that this block uses
-     */
-    models: string[]
-    /**
      * Description of this block (set by the user in a CMS, ideally)
      */
     description?: string
     /**
-     * The list of texture names referenced in the blockstates file.
-     * 
-     * Will be empty when:
-     * 1. This block doesn't use a blockstates file (the only place 'varaints' is defined)
-     * 2. This block's blockstate file uses 'multipart'
+     * The image to upload as the block pages main image
      */
-    variantModelNames?: string[]
+    icon?: Buffer
     /**
      * A list of the texture names associated with this Block.
      * 
@@ -114,14 +102,6 @@ export type BlockPage = {
     textures: {
         [fileName: string]: string
     }
-    /**
-     * A list of multipart JSON objects that this block uses
-     * 
-     * Will be empty when:
-     * 1. This block doesn't use a blockstates file (the only place 'multipart' is defined)
-     * 2. This block's blockstate file uses 'variants'
-     */
-    multipartCases: BlockstateMultipartCase[]
 }
 
 /**
@@ -151,9 +131,11 @@ export type ItemPage = {
     textures: Buffer[]
 }
 
+export type ParsedNamespaceData = {
+    blockPages?: BlockPage[],
+    itemPages?: ItemPage[]
+}
+
 export type ParsedData = {
-    [namespace: string]: {
-        blockPages?: BlockPage[],
-        itemPages?: ItemPage[]
-    }
+    [namespace: string]: ParsedNamespaceData
 }


### PR DESCRIPTION
# Description

Block page content was previously (and incorrectly) tied to the information stored in the `.../assets/<NAMESPACE>/blockstates` directory. This was incorrect because:
* Blockstates _use_ block models by describing how the corresponding block behaves in a variety of conditions
   * In other words, _blockstates do not define any new blocks_

## Changelog
* Update the `reset` script so that it also deletes the `generated` directory
* Implement `MinecraftAssetReader` class
* Remove old data parsing logic
* Commented out code that relied on changed types/logic - some of this logic will need to be reused later