### PR TITLE
Menu render fix after bootstrapping data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13499,6 +13499,11 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
     "string-length": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
@@ -13577,11 +13582,6 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "strip-ansi": {
       "version": "6.0.0",

--- a/src/CLIApp.tsx
+++ b/src/CLIApp.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import {
   useMenuOptions,
   useParsedData,
@@ -87,14 +87,14 @@ export const CLIApp = () => {
        * on the imported raw assets data
        */
       case OPTION_VALUE.BOOTSTRAP_DATA: {
-        // TODO: (BUG) Fix this so that it triggers the menu to update and all options render when they should
         CACHE_CLIENT.parseImportedData()
+          // De-select the selected option once the parse is complete
+          .then(() => setSelectedOption((null as unknown) as string))
         break
       }
-      default: {
-        setSelectedOption(option.value)
-      }
     }
+    // Always set the selected option, even if there is no GUI to render for the option
+    setSelectedOption(option.value)
   }
 
   return (

--- a/src/components/shared/Menu.tsx
+++ b/src/components/shared/Menu.tsx
@@ -11,12 +11,12 @@ export const Menu = (props: {
   }[]
   onSelectHandler: (option: { label: string; value: string }) => void
 }) => (
-    <>
-      <Box marginLeft={1}>
-        <Text bold color="blue">
-          {props.title}
-        </Text>
-      </Box>
-      <SelectInput items={props.options} onSelect={props.onSelectHandler} />
-    </>
-  )
+  <>
+    <Box marginLeft={1}>
+      <Text bold color="blue">
+        {props.title}
+      </Text>
+    </Box>
+    <SelectInput items={props.options} onSelect={props.onSelectHandler} />
+  </>
+)


### PR DESCRIPTION
# Description

After updating to functional components and Hooks, a bug was introduced where the menu wouldn't render the appropriate options after selecting the "Bootstrap" option. 

This PR fixes that bug.

## Changelog
1. Always set the selected option now (so that the state changes, and we have something to revert on succesful data parse)
2. De-select the selected option once data parse is complete

Menu renders options post-bootstrap successfully! :tada: 