### PR TITLE
Tests for useMenuOptions Hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@babel/preset-env": "^7.13.15",
         "@babel/preset-react": "^7.13.13",
         "@emotion/eslint-plugin": "^11.2.0",
+        "@testing-library/react-hooks": "^5.1.1",
         "@types/ink-big-text": "^1.2.0",
         "@types/ink-divider": "^2.0.1",
         "@types/ink-gradient": "^2.0.1",
@@ -2121,6 +2122,33 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@testing-library/react-hooks": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-5.1.1.tgz",
+      "integrity": "sha512-52D2XnpelFDefnWpy/V6z2qGNj8JLIvW5DjYtelMvFXdEyWiykSaI7IXHwFy4ICoqXJDmmwHAiFRiFboub/U5g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
+        "filter-console": "^0.1.1",
+        "react-error-boundary": "^3.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0",
+        "react-test-renderer": ">=16.9.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-test-renderer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.1.14",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
@@ -2416,6 +2444,15 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.3.tgz",
+      "integrity": "sha512-4NnJbCeWE+8YBzupn/YrJxZ8VnjcJq5iR1laqQ1vkpQgBiA7bwk0Rp24fxsdNinzJY2U+HHS4dJJDPdoMjdJ7w==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-test-renderer": {
@@ -5618,6 +5655,15 @@
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/filter-console": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/filter-console/-/filter-console-0.1.1.tgz",
+      "integrity": "sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -11268,6 +11314,22 @@
         "ws": "^7"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.1.tgz",
+      "integrity": "sha512-W3xCd9zXnanqrTUeViceufD3mIW8Ut29BUD+S2f0eO2XCOU8b6UrJfY46RDGe5lxCJzfe4j0yvIfh0RbTZhKJw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -15931,6 +15993,20 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-5.1.1.tgz",
+      "integrity": "sha512-52D2XnpelFDefnWpy/V6z2qGNj8JLIvW5DjYtelMvFXdEyWiykSaI7IXHwFy4ICoqXJDmmwHAiFRiFboub/U5g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
+        "filter-console": "^0.1.1",
+        "react-error-boundary": "^3.1.0"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.14",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
@@ -16224,6 +16300,15 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-dom": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.3.tgz",
+      "integrity": "sha512-4NnJbCeWE+8YBzupn/YrJxZ8VnjcJq5iR1laqQ1vkpQgBiA7bwk0Rp24fxsdNinzJY2U+HHS4dJJDPdoMjdJ7w==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
       }
     },
     "@types/react-test-renderer": {
@@ -18687,6 +18772,12 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "filter-console": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/filter-console/-/filter-console-0.1.1.tgz",
+      "integrity": "sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==",
+      "dev": true
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -23076,6 +23167,15 @@
       "requires": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.1.tgz",
+      "integrity": "sha512-W3xCd9zXnanqrTUeViceufD3mIW8Ut29BUD+S2f0eO2XCOU8b6UrJfY46RDGe5lxCJzfe4j0yvIfh0RbTZhKJw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "tsc",
     "reset": "rm -rf out/ generated/ && npm run build",
     "lint:commit": "prettier-eslint \"{src/**/*,test/**/*}.{ts,tsx}\" --eslint-config-path=.eslintrc.yml --write",
-    "test": "jest",
+    "test": "jest --verbose",
     "coverage": "jest --coverage",
     "prepare": "husky install"
   },
@@ -28,6 +28,7 @@
     "@babel/preset-env": "^7.13.15",
     "@babel/preset-react": "^7.13.13",
     "@emotion/eslint-plugin": "^11.2.0",
+    "@testing-library/react-hooks": "^5.1.1",
     "@types/ink-big-text": "^1.2.0",
     "@types/ink-divider": "^2.0.1",
     "@types/ink-gradient": "^2.0.1",

--- a/src/CLIApp.tsx
+++ b/src/CLIApp.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect } from "react"
 import { useState } from "react"
 import {
   useMenuOptions,

--- a/src/hooks/useMenuOptions.tsx
+++ b/src/hooks/useMenuOptions.tsx
@@ -1,10 +1,8 @@
 import { useState, useEffect } from "react"
 import { ParsedData, RawAssetData } from "../types"
 
-const enum OPTION_VALUE {
+export const enum OPTION_VALUE {
   SET_ASSETS_DIRECTORY = `set_assets_directory`,
-  IMPORT_DATA = `import_data`,
-  INSPECT_DATA = `inspect_data`,
   BOOTSTRAP_DATA = `bootstrap_data`,
   VIEW_RAW_DATA = `view_raw_data`,
   VIEW_PARSED_DATA = `view_parsed_data`,
@@ -12,12 +10,13 @@ const enum OPTION_VALUE {
 }
 
 export const useMenuOptions = (props: {
-  parsedData: ParsedData
-  rawData: RawAssetData
+  parsedData?: ParsedData
+  rawData?: RawAssetData
+  // Will never be null, just empty when unset
   rawAssetsPath: string
 }) => {
   const [options, setOptions] = useState(
-    [] as { label: string; value: string }[]
+    [] as { label: string; value: OPTION_VALUE }[]
   )
 
   useEffect(() => {
@@ -60,7 +59,12 @@ export const useMenuOptions = (props: {
     }
 
     setOptions(array)
-  }, [props.parsedData, props.rawAssetsPath, props.rawData])
+  }, [
+    // We don't want to re-render any time the underlying object changes; just when this goes from falsy to truthy
+    !!props.parsedData,
+    !!props.rawData,
+    props.rawAssetsPath,
+  ])
 
   return options
 }

--- a/src/hooks/useParsedData.tsx
+++ b/src/hooks/useParsedData.tsx
@@ -3,7 +3,7 @@ import { CACHE } from "../cache/cacheClient"
 import { ParsedData } from "../types"
 
 export const useParsedData = (props: { watch?: any }) => {
-  const [parsedData, setParsedData] = useState({} as ParsedData)
+  const [parsedData, setParsedData] = useState((null as unknown) as ParsedData)
 
   useEffect(() => {
     CACHE.getParsedDataFromCache().then((parsedData) => {

--- a/test/hooks/useMenuOptions.test.ts
+++ b/test/hooks/useMenuOptions.test.ts
@@ -1,0 +1,70 @@
+import { renderHook, act } from "@testing-library/react-hooks"
+import { useMenuOptions, OPTION_VALUE } from "../../src/hooks/useMenuOptions"
+import { ParsedData, RawAssetData } from "../../src/types"
+
+describe(`useMenuOptions Hook tests`, () => {
+  it(`returns the expected options when no assets path, raw data, or parsed data is set`, () => {
+    const { result } = renderHook(() =>
+      useMenuOptions({
+        rawAssetsPath: ``,
+        rawData: (null as unknown) as RawAssetData,
+        parsedData: (null as unknown) as ParsedData,
+      })
+    )
+
+    const optionCount = result.current.length
+    expect(optionCount).toBe(1)
+    const option = result.current[0]
+
+    expect(option.label).toBe(`Set assets directory`)
+    expect(option.value).toBe(OPTION_VALUE.SET_ASSETS_DIRECTORY)
+  })
+
+  it(`returns the expected options when an assets path is set, but the data has not been bootstrapped (e.g., rawData and parsedData are unset)`, () => {
+    const { result } = renderHook(() =>
+      useMenuOptions({
+        rawAssetsPath: `/some/path/to/assets`,
+        rawData: (null as unknown) as RawAssetData,
+        parsedData: (null as unknown) as ParsedData,
+      })
+    )
+
+    const optionCount = result.current.length
+    expect(optionCount).toBe(2)
+
+    const expectedOptions = [
+      OPTION_VALUE.SET_ASSETS_DIRECTORY,
+      OPTION_VALUE.BOOTSTRAP_DATA,
+    ]
+
+    result.current.forEach((option) => {
+      expect(expectedOptions.includes(option.value)).toBe(true)
+    })
+  })
+
+  it(`returns the expected options when the assets path, raw data and parsed data are all defined`, () => {
+    const { result } = renderHook(() =>
+      useMenuOptions({
+        rawAssetsPath: `/some/path/to/assets`,
+        // The objects for parsed- and rawData don't need to be accurate for this test - they just need to be "defined" (even if just an empty object)
+        rawData: {} as RawAssetData,
+        parsedData: {} as ParsedData,
+      })
+    )
+
+    const optionCount = result.current.length
+    expect(optionCount).toBe(5)
+
+    const expectedOptions = [
+      OPTION_VALUE.SET_ASSETS_DIRECTORY,
+      OPTION_VALUE.BOOTSTRAP_DATA,
+      OPTION_VALUE.VIEW_RAW_DATA,
+      OPTION_VALUE.VIEW_PARSED_DATA,
+      OPTION_VALUE.EXPORT_PARSED_DATA,
+    ]
+
+    result.current.forEach((option) => {
+      expect(expectedOptions.includes(option.value)).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
# Description

Add tests for `useMenuOption` custom Hook.

## Changelog
* Tests for `useMenuOption` Hook
* Bug fix for `useMenuOption`; prevents unnecessary re-renders (was previously updating with _any_ change to the larger data objects; we just needed to check for existence in the dependencies)