### PR TITLE
Make husky less annoying

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run lint:commit
+yarn test

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean": "rm -rf out/ generated/ dist/",
     "reset": "yarn clean && npm run build",
     "lint:commit": "prettier-eslint \"{src/**/*,test/**/*}.{ts,tsx}\" --eslint-config-path=.eslintrc.yml --write",
-    "test": "jest --verbose",
+    "test": "jest --verbose=false",
     "coverage": "jest --coverage",
     "prepare": "husky install",
     "start": "LOCAL=true ts-node ./src/main.tsx"

--- a/test/hooks/useMenuOptions.test.ts
+++ b/test/hooks/useMenuOptions.test.ts
@@ -1,6 +1,6 @@
-import { renderHook, act } from "@testing-library/react-hooks"
-import { useMenuOptions, OPTION_VALUE } from "../../src/hooks/useMenuOptions"
-import { ParsedData, RawAssetData } from "../../src/types"
+import { renderHook } from "@testing-library/react-hooks"
+import { useMenuOptions, OPTION_VALUE } from "../../src/components/hooks/useMenuOptions"
+import { RawAssetData, SiteData } from "../../src/types"
 
 describe(`useMenuOptions Hook tests`, () => {
   it(`returns the expected options when no assets path, raw data, or parsed data is set`, () => {
@@ -8,7 +8,7 @@ describe(`useMenuOptions Hook tests`, () => {
       useMenuOptions({
         rawAssetsPath: ``,
         rawData: (null as unknown) as RawAssetData,
-        parsedData: (null as unknown) as ParsedData,
+        parsedData: (null as unknown) as SiteData,
       })
     )
 
@@ -25,7 +25,7 @@ describe(`useMenuOptions Hook tests`, () => {
       useMenuOptions({
         rawAssetsPath: `/some/path/to/assets`,
         rawData: (null as unknown) as RawAssetData,
-        parsedData: (null as unknown) as ParsedData,
+        parsedData: (null as unknown) as SiteData,
       })
     )
 
@@ -48,19 +48,16 @@ describe(`useMenuOptions Hook tests`, () => {
         rawAssetsPath: `/some/path/to/assets`,
         // The objects for parsed- and rawData don't need to be accurate for this test - they just need to be "defined" (even if just an empty object)
         rawData: {} as RawAssetData,
-        parsedData: {} as ParsedData,
+        parsedData: {} as SiteData,
       })
     )
 
     const optionCount = result.current.length
-    expect(optionCount).toBe(5)
+    expect(optionCount).toBe(2)
 
     const expectedOptions = [
       OPTION_VALUE.SET_ASSETS_DIRECTORY,
       OPTION_VALUE.BOOTSTRAP_DATA,
-      OPTION_VALUE.VIEW_RAW_DATA,
-      OPTION_VALUE.VIEW_PARSED_DATA,
-      OPTION_VALUE.EXPORT_PARSED_DATA,
     ]
 
     result.current.forEach((option) => {


### PR DESCRIPTION
* Run tests instead of `lint:commit` (should rename this later)
   * `lint:commit` was leading to further changes that also needed to be committed, and the subsequent husky hook event may trigger yet more changes (in some cases, I had 2 extra commits just to get one change committed)
* Fix tests