### PR TITLE
Support for getting blocks in descending order

### DIFF
--- a/src/api/raw-data/getBlocksForNamespace.ts
+++ b/src/api/raw-data/getBlocksForNamespace.ts
@@ -15,7 +15,7 @@ export function getBlocksForNamespace(
   res: express.Response
 ) {
   // If limit is unset, it defaults to 10
-  const { namespace, limit, skip, page, block, scaleImage } = req.query
+  const { namespace, limit, page, block, scaleImage, order } = req.query
   if (!namespace) {
     res.send({
       error: `You must provide a namespace`,
@@ -35,6 +35,7 @@ export function getBlocksForNamespace(
       namespace: namespace as string,
       limit: !!limit ? ((limit as unknown) as Int) : undefined,
       page: !!page ? ((page as unknown) as Int) : undefined,
+      order: !!order ? (order as `ascending` | `descending`) : undefined,
     })
     const response = {
       limit: (limit as unknown) as number,

--- a/src/services/core/cache/index.ts
+++ b/src/services/core/cache/index.ts
@@ -38,6 +38,7 @@ export default class AppCache {
     namespace: string
     page?: Int
     limit?: Int
+    order?: `ascending` | `descending`
   }) => {
     const { limit, namespace, page } = args
     const rawData = this.rawData()
@@ -47,6 +48,9 @@ export default class AppCache {
     }[]
     const blocksForNamespace = rawData[namespace].model.block
     const blockNames = Object.keys(blocksForNamespace)
+    if (!!args.order && args.order === `descending`) {
+      blockNames.reverse()
+    }
     const pageCount = Math.ceil(
       blockNames.length / ((limit as unknown) as number)
     )


### PR DESCRIPTION
# Description

Endpoint to get blocks for namespace now supports a `sort` parameter. Technically `ascending` is a supported value, but nothing changes with the logic.

When `sort=descending`, the block pages are reversed (descending order).