### PR TITLE
Search blocks by string

### DIFF
--- a/src/api/raw-data/getBlocksForNamespace.ts
+++ b/src/api/raw-data/getBlocksForNamespace.ts
@@ -15,7 +15,7 @@ export function getBlocksForNamespace(
   res: express.Response
 ) {
   // If limit is unset, it defaults to 10
-  const { namespace, limit, page, block, scaleImage, order } = req.query
+  const { namespace, limit, page, block, scaleImage, order, q } = req.query
   if (!namespace) {
     res.send({
       error: `You must provide a namespace`,
@@ -36,6 +36,7 @@ export function getBlocksForNamespace(
       limit: !!limit ? ((limit as unknown) as Int) : undefined,
       page: !!page ? ((page as unknown) as Int) : undefined,
       order: !!order ? (order as `ascending` | `descending`) : undefined,
+      q: !!q ? (q as string) : undefined,
     })
     const response = {
       limit: (limit as unknown) as number,

--- a/src/services/core/cache/index.ts
+++ b/src/services/core/cache/index.ts
@@ -39,6 +39,7 @@ export default class AppCache {
     page?: Int
     limit?: Int
     order?: `ascending` | `descending`
+    q?: string
   }) => {
     const { limit, namespace, page } = args
     const rawData = this.rawData()
@@ -47,7 +48,15 @@ export default class AppCache {
       data: BlockModelData
     }[]
     const blocksForNamespace = rawData[namespace].model.block
-    const blockNames = Object.keys(blocksForNamespace)
+    let blockNames = [] as string[]
+    if (!!args.q) {
+      blockNames = Object.keys(blocksForNamespace).filter((val) =>
+        val.includes(args.q!)
+      )
+    } else {
+      blockNames = Object.keys(blocksForNamespace)
+    }
+
     if (!!args.order && args.order === `descending`) {
       blockNames.reverse()
     }


### PR DESCRIPTION
# Description

The `raw-data/blocks` endpoint now accepts an optional parameter, `q`. Pass a search string through this variable to filter the blocks by the given string.