### PR TITLE
Config for self-hosted web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 out
 generated
 .env
+build
 
 # TODO:
 report.**.json

--- a/src/services/core/server/server.ts
+++ b/src/services/core/server/server.ts
@@ -10,9 +10,15 @@ import {
   writeContentMapToDisk,
 } from "../../../api/content-map"
 import { writeSiteDataToDisk, exportToSanity } from "../../../api/site-data"
+import path from "path"
 
 var app = express()
 
+// Needed for React app
+app.use(express.static(path.join(__dirname, `../../../..`, `build`)))
+app.use(express.static(`public`))
+
+// Remaining stuff
 app.use(express.urlencoded({ extended: true }))
 app.use(express.json())
 app.use(cors())


### PR DESCRIPTION
# Description

Enables self-hosting the Minecraft Asset Reader webapp.

This will not work without first:
1. Build the webapp > copy the `build` directory
2. Paste the `build` directory at the `minecraft-asset-reader` directory

Once you've copied the `build` directory over, you will be able to access it by navigating to `localhost:3000` in the browser. The `build` directory SHOULD NOT be committed; we need to set up a build pipeline later that will handle this for us (probably in a slightly-different setup as well).