### PR TITLE
New fields on block config modal

### DIFF
--- a/packages/client/src/BlockModalNumberInput.tsx
+++ b/packages/client/src/BlockModalNumberInput.tsx
@@ -1,0 +1,17 @@
+import React from "react"
+
+export const BlockModalNumberInput = (props: {
+  label: string
+  value: number
+  onChangeHandler: (e: React.ChangeEvent<HTMLInputElement>) => void
+}) => (
+  <div>
+    {props.label}
+    <input
+      className="flex float-right w-10 focus:outline-none"
+      type="number"
+      value={props.value}
+      onChange={props.onChangeHandler}
+    />
+  </div>
+)


### PR DESCRIPTION
Adds new fields to the block config modal; back end needs to be wired up, still.

Example screenshot of changes
![image](https://user-images.githubusercontent.com/14364659/117413144-37abaa00-aedb-11eb-912a-c3bfee7ee0bf.png)
