### PR TITLE
Get harvest tool/qualities endpoints

### DIFF
--- a/packages/cli/src/api/content-map/UPDATED/addOrUpdateBlock.ts
+++ b/packages/cli/src/api/content-map/UPDATED/addOrUpdateBlock.ts
@@ -1,5 +1,5 @@
 import express from "express"
-import { Dao } from "../../services/db"
+import { Dao } from "../../../services/db"
 
 export function addOrUpdateBlock(req: express.Request, res: express.Response) {
   const {

--- a/packages/cli/src/api/content-map/UPDATED/getBlocks.ts
+++ b/packages/cli/src/api/content-map/UPDATED/getBlocks.ts
@@ -1,5 +1,5 @@
 import express from "express"
-import { Dao } from "../../services/db"
+import { Dao } from "../../../services/db"
 
 export function getBlocks(req: express.Request, res: express.Response) {
   const { q } = req.query

--- a/packages/cli/src/api/content-map/UPDATED/getHarvestToolQualities.ts
+++ b/packages/cli/src/api/content-map/UPDATED/getHarvestToolQualities.ts
@@ -1,0 +1,11 @@
+import express from "express"
+import { Dao } from "../../../services/db"
+
+export function getHarvestToolQualities(
+  req: express.Request,
+  res: express.Response
+) {
+  Dao().then((db) =>
+    db.getHarvestToolQualities().then((result) => res.send(result))
+  )
+}

--- a/packages/cli/src/api/content-map/UPDATED/getHarvestTools.ts
+++ b/packages/cli/src/api/content-map/UPDATED/getHarvestTools.ts
@@ -1,0 +1,6 @@
+import express from "express"
+import { Dao } from "../../../services/db"
+
+export function getHarvestTools(req: express.Request, res: express.Response) {
+  Dao().then((db) => db.getHarvestTools().then((result) => res.send(result)))
+}

--- a/packages/cli/src/services/core/server/server.ts
+++ b/packages/cli/src/services/core/server/server.ts
@@ -11,8 +11,10 @@ import {
 } from "../../../api/content-map"
 import { writeSiteDataToDisk, exportToSanity } from "../../../api/site-data"
 import path from "path"
-import { addOrUpdateBlock } from "../../../api/content-map/addOrUpdateBlock"
-import { getBlocks } from "../../../api/content-map/getBlocks"
+import { addOrUpdateBlock } from "../../../api/content-map/UPDATED/addOrUpdateBlock"
+import { getBlocks } from "../../../api/content-map/UPDATED/getBlocks"
+import { getHarvestTools } from "../../../api/content-map/UPDATED/getHarvestTools"
+import { getHarvestToolQualities } from "../../../api/content-map/UPDATED/getHarvestToolQualities"
 
 var app = express()
 
@@ -55,8 +57,17 @@ app.get(`/content-map/block`, getBlockFromContentMap)
 app.post(`/content-map/blocks`, setContentMapNamespaceBlocks)
 app.post(`/content-map/export`, writeContentMapToDisk)
 
+/*******************************************
+ * Block API routes
+ *******************************************/
 app.get(`/block`, getBlocks)
 app.post(`/block`, addOrUpdateBlock)
+
+/*******************************************
+ * Harvest Tool API routes
+ *******************************************/
+app.get(`/harvest-tool`, getHarvestTools)
+app.get(`/harvest-tool/quality`, getHarvestToolQualities)
 
 /*******************************************
  * Site data routes

--- a/packages/cli/src/services/db/index.ts
+++ b/packages/cli/src/services/db/index.ts
@@ -38,13 +38,13 @@ export async function Dao() {
       // TODO: stop simply replacing the values; make this logic conditional based on if data already exists (replacing updates the IDs)
       // Populate the harvest_tool table
       var popHarvestToolsResult = await db.run(
-        `INSERT OR REPLACE INTO harvest_tool (key) VALUES (?),(?),(?),(?),(?),(?)`,
+        `INSERT OR IGNORE INTO harvest_tool (key) VALUES (?),(?),(?),(?),(?),(?)`,
         [`axe`, `hoe`, `pickaxe`, `shovel`, `hand`, `none`]
       )
 
       // Populate the harvest_tool_quality table
       var popHarvestToolQualitiesResult = await db.run(
-        `INSERT OR REPLACE INTO harvest_tool_quality (key) VALUES (?),(?),(?),(?),(?),(?),(?)`,
+        `INSERT OR IGNORE INTO harvest_tool_quality (key) VALUES (?),(?),(?),(?),(?),(?),(?)`,
         [`wood`, `stone`, `iron`, `gold`, `diamond`, `netherite`, `none`]
       )
 
@@ -62,11 +62,13 @@ export async function Dao() {
      * @returns Array of all harvest tools
      */
     getHarvestTools: async () => {
-      const toolsResult = await db.get(
-        `SELECT rowid AS id, key FROM harvest_tool`
-      )
+      const harvestTools = [] as any[]
+      await db.each(`SELECT rowid AS id, key FROM harvest_tool`, (err, row) => {
+        if (err) console.log(`ERROR: `, err.message)
+        harvestTools.push(row)
+      })
       await db.close()
-      return toolsResult
+      return harvestTools
     },
     /**
      * Get the list of harvest tool qualities for tools used to break blocks, indicating the "tier"
@@ -83,11 +85,16 @@ export async function Dao() {
      * @returns Array of all harvest tools
      */
     getHarvestToolQualities: async () => {
-      const getHarvestToolQualitiesResult = await db.get(
-        `SELECT rowid AS id, key FROM harvest_tool_quality`
+      const harvestToolQualities = [] as any[]
+      await db.each(
+        `SELECT rowid AS id, key FROM harvest_tool_quality`,
+        (err, row) => {
+          if (err) console.log(`ERROR: `, err.message)
+          harvestToolQualities.push(row)
+        }
       )
       await db.close()
-      return getHarvestToolQualitiesResult
+      return harvestToolQualities
     },
     /**
      * Add a new block, if it doesn't exist, or update the existing one if it does


### PR DESCRIPTION
# Description

Adds two new endpoints:
1. `/harvest-tool`
2. `/harvest-tool/quality`

Both of these endpoints are extremely simple GET endpoints; no parameters are required since the data set is always small; simply work with the resulting data set.

## Example request-response

### Request
* `GET` to `http://localhost:3000/harvest-tool`
* `GET` to `http://localhost:3000/harvest-tool/quality`

### Response

Harvest tool response:
```
[
    {
        "id": 1,
        "key": "axe"
    },
    {
        "id": 2,
        "key": "hoe"
    },
    {
        "id": 3,
        "key": "pickaxe"
    },
    {
        "id": 4,
        "key": "shovel"
    },
    {
        "id": 5,
        "key": "hand"
    },
    {
        "id": 6,
        "key": "none"
    }
]
```

Harvest tool quality response:
```
[
    {
        "id": 1,
        "key": "wood"
    },
    {
        "id": 2,
        "key": "stone"
    },
    {
        "id": 3,
        "key": "iron"
    },
    {
        "id": 4,
        "key": "gold"
    },
    {
        "id": 5,
        "key": "diamond"
    },
    {
        "id": 6,
        "key": "netherite"
    },
    {
        "id": 7,
        "key": "none"
    }
]
```

