### PR TITLE
Delete block endpoint

### DIFF
--- a/packages/cli/src/api/content-map/UPDATED/deleteBlock.ts
+++ b/packages/cli/src/api/content-map/UPDATED/deleteBlock.ts
@@ -1,0 +1,18 @@
+import express from "express"
+import { Dao } from "../../../services/db"
+
+export function deleteBlock(req: express.Request, res: express.Response) {
+  const { key } = req.query
+
+  if (!key) {
+    res.status(422).send(`'key' parameter is required`)
+  }
+
+  Dao().then((db) =>
+    db
+      .deleteBlock({
+        key: key as string,
+      })
+      .then((result) => res.send(result))
+  )
+}

--- a/packages/cli/src/services/core/server/server.ts
+++ b/packages/cli/src/services/core/server/server.ts
@@ -15,6 +15,7 @@ import { addOrUpdateBlock } from "../../../api/content-map/UPDATED/addOrUpdateBl
 import { getBlocks } from "../../../api/content-map/UPDATED/getBlocks"
 import { getHarvestTools } from "../../../api/content-map/UPDATED/getHarvestTools"
 import { getHarvestToolQualities } from "../../../api/content-map/UPDATED/getHarvestToolQualities"
+import { deleteBlock } from "../../../api/content-map/UPDATED/deleteBlock"
 
 var app = express()
 
@@ -62,6 +63,7 @@ app.post(`/content-map/export`, writeContentMapToDisk)
  *******************************************/
 app.get(`/block`, getBlocks)
 app.post(`/block`, addOrUpdateBlock)
+app.delete(`/block`, deleteBlock)
 
 /*******************************************
  * Harvest Tool API routes

--- a/packages/cli/src/services/db/index.ts
+++ b/packages/cli/src/services/db/index.ts
@@ -244,5 +244,10 @@ export async function Dao() {
       await db.close()
       return blocks
     },
+    deleteBlock: async (args: { key: string }) => {
+      const response = await db.run(`DELETE FROM block WHERE key = ?`, args.key)
+      console.log(`DELETE BLOCK RESPONSE: `, response)
+      return response
+    },
   }
 }


### PR DESCRIPTION
# Description

Delete a _configured_ block. Note that there is no way to delete blocks from the "raw data" map; we don't want to remove those since those serve as the "raw list" that the user selects and configures blocks from.

**The database implementation will replace the Content Map ONLY - the raw data format will stay the same**

## Example request and response

### Request
* `DELETE` to `http://localhost:3000/block?key=test`
   * Where `test` is the key value for the block being deleted

### Response (when something was deleted):
```
{
    "stmt": {},
    "lastID": 0,
    "changes": 1
}
```
* Note the `changes` value - indicates how many rows were changed

### Response (when there was NOTHING to delete):
```
{
    "stmt": {},
    "lastID": 0,
    "changes": 0
}
```