### PR TITLE
Game version specific SQLite databases

### DIFF
--- a/packages/cli/src/api/content-map/UPDATED/addOrUpdateBlock.ts
+++ b/packages/cli/src/api/content-map/UPDATED/addOrUpdateBlock.ts
@@ -4,6 +4,7 @@ import { Dao } from "../../../services/db"
 export function addOrUpdateBlock(req: express.Request, res: express.Response) {
   const {
     key,
+    gameVersion,
     title,
     icon,
     description,
@@ -14,10 +15,10 @@ export function addOrUpdateBlock(req: express.Request, res: express.Response) {
     maxSpawn,
   } = req.body
 
-  if (!key) {
-    res.status(422).send(`'key' parameter is required`)
+  if (!key || !gameVersion) {
+    res.status(422).send(`'key' and 'gameVersion' parameters are required`)
   } else {
-    Dao()
+    Dao(gameVersion)
       .then((db) =>
         db.addOrUpdateBlock({
           key,

--- a/packages/cli/src/api/content-map/UPDATED/deleteBlock.ts
+++ b/packages/cli/src/api/content-map/UPDATED/deleteBlock.ts
@@ -2,13 +2,13 @@ import express from "express"
 import { Dao } from "../../../services/db"
 
 export function deleteBlock(req: express.Request, res: express.Response) {
-  const { key } = req.query
+  const { gameVersion, key } = req.query
 
-  if (!key) {
-    res.status(422).send(`'key' parameter is required`)
+  if (!key || !gameVersion) {
+    res.status(422).send(`'key' and 'gameVersion' parameters are required`)
   }
 
-  Dao().then((db) =>
+  Dao(gameVersion as string).then((db) =>
     db
       .deleteBlock({
         key: key as string,

--- a/packages/cli/src/api/content-map/UPDATED/getBlocks.ts
+++ b/packages/cli/src/api/content-map/UPDATED/getBlocks.ts
@@ -2,9 +2,13 @@ import express from "express"
 import { Dao } from "../../../services/db"
 
 export function getBlocks(req: express.Request, res: express.Response) {
-  const { q } = req.query
+  const { gameVersion, q } = req.query
 
-  Dao().then((db) =>
+  if (!gameVersion) {
+    res.status(422).send(`'gameVersion' parameter is required`)
+  }
+
+  Dao(gameVersion as string).then((db) =>
     db
       .getBlocks({
         search: q as string | undefined,

--- a/packages/cli/src/api/content-map/UPDATED/getHarvestToolQualities.ts
+++ b/packages/cli/src/api/content-map/UPDATED/getHarvestToolQualities.ts
@@ -5,7 +5,13 @@ export function getHarvestToolQualities(
   req: express.Request,
   res: express.Response
 ) {
-  Dao().then((db) =>
+  const { gameVersion } = req.query
+
+  if (!gameVersion) {
+    res.status(422).send(`'gameVersion' parameter is required`)
+  }
+
+  Dao(gameVersion as string).then((db) =>
     db.getHarvestToolQualities().then((result) => res.send(result))
   )
 }

--- a/packages/cli/src/api/content-map/UPDATED/getHarvestTools.ts
+++ b/packages/cli/src/api/content-map/UPDATED/getHarvestTools.ts
@@ -2,5 +2,11 @@ import express from "express"
 import { Dao } from "../../../services/db"
 
 export function getHarvestTools(req: express.Request, res: express.Response) {
-  Dao().then((db) => db.getHarvestTools().then((result) => res.send(result)))
+  const { gameVersion } = req.query
+  if (!gameVersion) {
+    res.status(422).send(`'gameVersion' parameter is required`)
+  }
+  Dao(gameVersion as string).then((db) =>
+    db.getHarvestTools().then((result) => res.send(result))
+  )
 }

--- a/packages/cli/src/main.tsx
+++ b/packages/cli/src/main.tsx
@@ -3,14 +3,11 @@ import React from "react"
 import AppCache from "./services/core/cache"
 import { CLIApp } from "./CLIApp"
 import { initServer } from "./services/core/server/server"
-import { Dao } from "./services/db"
 
 export const CACHE = new AppCache()
 
 export function cli(_args: any) {
   initServer()
-    .then(() => Dao())
-    .then((db) => db.initDb())
     .then(() => render(<CLIApp />))
     .catch((e) => console.error(e))
 }

--- a/packages/cli/src/services/core/cache/index.ts
+++ b/packages/cli/src/services/core/cache/index.ts
@@ -15,6 +15,7 @@ const enum KEYS {
   RAW_DATA = `raw_data`,
   SITE_DATA = `site_data`,
   ASSETS_PATH = `assets_path`,
+  GAME_VERSION = `game_version`,
 }
 
 export default class AppCache {
@@ -216,5 +217,23 @@ export default class AppCache {
 
   getRootAssetsPath() {
     return this.cache.get(KEYS.ASSETS_PATH)
+  }
+
+  /**
+   * Set the game version
+   *
+   * The cached game version is how we know which database to use (or create). A database is not initialized until the
+   * user specifies where they want to import assets from. If it's a game version they have imported before, then we
+   * load the existing database so that they can review their previous configuration and optionally update if they want
+   * to.
+   *
+   * @param version
+   */
+  setGameVersion(version: string) {
+    return this.cache.set(KEYS.GAME_VERSION, version)
+  }
+
+  getGameVersion() {
+    return this.cache.get(KEYS.GAME_VERSION)
   }
 }

--- a/packages/cli/src/services/db/index.ts
+++ b/packages/cli/src/services/db/index.ts
@@ -9,16 +9,22 @@ import {
 } from "./mutations/createTables"
 import { Int, MutationResult } from "../../types/shared"
 import { LIMIT } from "./constants"
+import mkdirp from "mkdirp"
 const sqlite3 = sqlitePkg.verbose()
 
+// TODO: https://www.sqlitetutorial.net/sqlite-foreign-key/
 /**
  * Closure to connect to the underlying SQLite database - returned methods use the database
  * connection
  *
  * @returns an object containing all necessary database operations for the minecraft asset reader app to function
  */
-export async function Dao() {
-  const fp = `/tmp/data.db`
+export async function Dao(gameVersion: string) {
+  /**
+   * All game version database files are stored in /tmp/minecraft-asset-reader (on UNIX - still needs Windows support)
+   */
+  await mkdirp(`/tmp/minecraft-asset-reader/`)
+  const fp = `/tmp/minecraft-asset-reader/${gameVersion}.db`
   const db = await open({
     filename: fp,
     driver: sqlite3.Database,
@@ -246,7 +252,6 @@ export async function Dao() {
     },
     deleteBlock: async (args: { key: string }) => {
       const response = await db.run(`DELETE FROM block WHERE key = ?`, args.key)
-      console.log(`DELETE BLOCK RESPONSE: `, response)
       return response
     },
   }


### PR DESCRIPTION
# Description

Now, instead of an app-specific database, the _app creates a database_ for the user once they provide a valid path to the assets directory. This allows us to persist separate "instances" of data; for example, if a user has multiple mods to configure, this implementation makes sure that each mod's data stays separate.

## Notable changes
* Database creation is deferred until a valid assets path has been submitted
* Each existing database-connected API now requires an additional parameter, `gameVersion`
    * _This allows the application to serve up persisted data from previous sessions, despite the cached data only being specific to the currently-imported game version; in other words, the web app will only ever show the currently-imported game version, but you can query for data from **any** game version that you've already imported and configured, so long as the CLI app is running_

### How does this affect the web app?

Nada! The database APIs are not yet hooked up to the client.