### PR TITLE
Unify return values for mutations

### DIFF
--- a/packages/cli/src/main.tsx
+++ b/packages/cli/src/main.tsx
@@ -11,7 +11,7 @@ export function cli(_args: any) {
   initServer()
     .then(() => Dao())
     .then((db) => db.initMainDb())
-    .then(() => render(<CLIApp />))
+    .then((_initResult) => render(<CLIApp />))
     .catch((e) => console.error(e))
 }
 

--- a/packages/cli/src/services/core/components/SetAssetsPathForm.tsx
+++ b/packages/cli/src/services/core/components/SetAssetsPathForm.tsx
@@ -32,7 +32,7 @@ export const SetAssetsPathForm = (props: {
        */
       Dao(gameVersion!)
         .then((db) => db.initGameVersionDatabase())
-        .then(() => Dao())
+        .then((_initDbResult) => Dao())
         .then((db) => db.addImportedGameVersion(gameVersion))
         .then(() => {
           minecraftAssetReader.readInRawData({

--- a/packages/cli/src/services/core/server/server.ts
+++ b/packages/cli/src/services/core/server/server.ts
@@ -59,7 +59,7 @@ app.use(`/imported`, (req, res, next) => {
   if (req.body) {
     ver = req.body.gameVersion as string | undefined
   }
-  if (req.query) {
+  if (!!req.query && !ver) {
     const { gameVersion } = req.query
     ver = gameVersion as string | undefined
   }


### PR DESCRIPTION
# Description

All db-linked mutations now return data in the shape of a `MutationResult`, which contains:
* `success` - whether or not the mutation operation happened as expected
* `message` - an optional message describing the return value (this is useful when returning error text to the caller)