### PR TITLE
Add and get namespaces APIs

### DIFF
--- a/packages/cli/src/api/content-map/UPDATED/addNamespace.ts
+++ b/packages/cli/src/api/content-map/UPDATED/addNamespace.ts
@@ -1,0 +1,17 @@
+import express from "express"
+import { Dao } from "../../../services/db"
+
+export function addNamespace(req: express.Request, res: express.Response) {
+  const { key, gameVersion } = req.body
+
+  if (!key) {
+    res.status(422).send(`'key' parameter is required`)
+  } else {
+    Dao(gameVersion)
+      .then((db) => db.addNamespace(key))
+      .then((result) => {
+        res.send(result)
+      })
+      .catch((e) => res.status(422).status(e))
+  }
+}

--- a/packages/cli/src/api/content-map/UPDATED/addOrUpdateBlock.ts
+++ b/packages/cli/src/api/content-map/UPDATED/addOrUpdateBlock.ts
@@ -15,8 +15,8 @@ export function addOrUpdateBlock(req: express.Request, res: express.Response) {
     maxSpawn,
   } = req.body
 
-  if (!key || !gameVersion) {
-    res.status(422).send(`'key' and 'gameVersion' parameters are required`)
+  if (!key) {
+    res.status(422).send(`'key' parameter is required`)
   } else {
     Dao(gameVersion)
       .then((db) =>

--- a/packages/cli/src/api/content-map/UPDATED/getNamespaces.ts
+++ b/packages/cli/src/api/content-map/UPDATED/getNamespaces.ts
@@ -1,0 +1,15 @@
+import express from "express"
+import { Dao } from "../../../services/db"
+
+export function getNamespacesFromDb(
+  req: express.Request,
+  res: express.Response
+) {
+  const { gameVersion } = req.query
+  Dao(gameVersion as string).then((db) =>
+    db
+      .getNamespaces()
+      .then((result) => res.send(result))
+      .catch((e) => res.status(422).status(e))
+  )
+}

--- a/packages/cli/src/services/core/server/server.ts
+++ b/packages/cli/src/services/core/server/server.ts
@@ -18,6 +18,8 @@ import { getHarvestToolQualities } from "../../../api/content-map/UPDATED/getHar
 import { deleteBlock } from "../../../api/content-map/UPDATED/deleteBlock"
 import { getImportedGameVersions } from "../../../api/content-map/UPDATED/getImportedGameVersions"
 import { Dao } from "../../db"
+import { addNamespace } from "../../../api/content-map/UPDATED/addNamespace"
+import { getNamespacesFromDb } from "../../../api/content-map/UPDATED/getNamespaces"
 
 var app = express()
 
@@ -106,11 +108,15 @@ app.post(`/content-map/export`, writeContentMapToDisk)
 app.get(`/core/imported-versions`, getImportedGameVersions)
 
 /*******************************************
- * Block API routes
+ * Game version-specific API routes
  *******************************************/
+// Blocks
 app.get(`/imported/block`, getBlocks)
 app.post(`/imported/block`, addOrUpdateBlock)
 app.delete(`/imported/block`, deleteBlock)
+// Namespaces
+app.get(`/imported/namespace`, getNamespacesFromDb)
+app.post(`/imported/namespace`, addNamespace)
 
 /*******************************************
  * Harvest Tool API routes

--- a/packages/cli/src/services/db/mutations/createTables.ts
+++ b/packages/cli/src/services/db/mutations/createTables.ts
@@ -37,7 +37,7 @@ export const CREATE_BLOCK_TABLE = `CREATE TABLE IF NOT EXISTS block (
 
 export const CREATE_NAMESPACE_TABLE = `CREATE TABLE IF NOT EXISTS namespace (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    key         TEXT    NOT NULL,
+    key         TEXT    NOT NULL UNIQUE,
     block_id    INTEGER,
     FOREIGN KEY (block_id) REFERENCES block (block_id) ON DELETE CASCADE ON UPDATE CASCADE
 )`


### PR DESCRIPTION
# Description

Adds two new APIs:
* `GET` - `/imported/namespace` - gets a list of all stored namespaces in the specified game version DB
* `POST` - `/imported/namespace` - create a new namespace; this endpoint is intended to be used when the user selects a namespace to in which to configure content (e.g., blocks, items, recipes, etc)

Both APIs require the `gameVersion` parameter; for the `POST` endpoint, include it as an additional `body` parameter. For the `GET` endpoint, it's just a query parameter.