### PR TITLE
Add block to db on save

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
+    "dotenv": "^9.0.2",
     "minecraft-asset-reader": "file:packages/cli",
     "minecraft-asset-reader-webapp": "file:packages/client"
   },

--- a/packages/cli/src/api/content-map/UPDATED/addOrUpdateBlock.ts
+++ b/packages/cli/src/api/content-map/UPDATED/addOrUpdateBlock.ts
@@ -1,12 +1,22 @@
 import express from "express"
 import { Dao } from "../../../services/db"
+import {
+  LIGHT_DIRECTION,
+  MinecraftBlockRenderer,
+} from "../../../services/minecraft"
 
-export function addOrUpdateBlock(req: express.Request, res: express.Response) {
-  const {
+export async function addOrUpdateBlock(
+  req: express.Request,
+  res: express.Response
+) {
+  var {
     key,
+    namespace,
     gameVersion,
     title,
     icon,
+    // When iconData is provided, the icon will be set/updated using the given texture info
+    iconData,
     description,
     flammabilityEncouragementValue,
     flammability,
@@ -18,10 +28,22 @@ export function addOrUpdateBlock(req: express.Request, res: express.Response) {
   if (!key) {
     res.status(422).send(`'key' parameter is required`)
   } else {
+    if (!!iconData) {
+      const renderer = new MinecraftBlockRenderer()
+      const iconBuffer = await renderer.drawBlockPageIcon({
+        namespace,
+        blockKey: key,
+        blockIconData: iconData,
+        lightDirection: LIGHT_DIRECTION.LEFT,
+      })
+      icon = iconBuffer.toString(`base64`)
+    }
+
     Dao(gameVersion)
       .then((db) =>
         db.addOrUpdateBlock({
           key,
+          namespace,
           title,
           icon,
           description,

--- a/packages/cli/src/api/content-map/UPDATED/getNamespaces.ts
+++ b/packages/cli/src/api/content-map/UPDATED/getNamespaces.ts
@@ -5,10 +5,10 @@ export function getNamespacesFromDb(
   req: express.Request,
   res: express.Response
 ) {
-  const { gameVersion } = req.query
+  const { gameVersion, q } = req.query
   Dao(gameVersion as string).then((db) =>
     db
-      .getNamespaces()
+      .getNamespaces(q as string | undefined)
       .then((result) => res.send(result))
       .catch((e) => res.status(422).status(e))
   )

--- a/packages/cli/src/services/core/server/server.ts
+++ b/packages/cli/src/services/core/server/server.ts
@@ -58,6 +58,7 @@ app.use(`/`, (req, res, next) => {
  */
 app.use(`/imported`, (req, res, next) => {
   let ver: string | undefined
+  // TODO: Make these mutually-exclusive (either body OR query)
   if (req.body) {
     ver = req.body.gameVersion as string | undefined
   }

--- a/packages/cli/src/services/db/mutations/createTables.ts
+++ b/packages/cli/src/services/db/mutations/createTables.ts
@@ -29,17 +29,17 @@ export const CREATE_BLOCK_TABLE = `CREATE TABLE IF NOT EXISTS block (
     harvest_tool_quality_id     INTEGER,
     related_blocks              INTEGER,
     ingredient_for_blocks       INTEGER,
+    namespace_id                INTEGER,
     FOREIGN KEY (harvest_tool_id) REFERENCES harvest_tool (harvest_tool_id) ON DELETE NO ACTION ON UPDATE NO ACTION,
     FOREIGN KEY (harvest_tool_quality_id) REFERENCES harvest_tool_quality (harvest_tool_quality_id) ON DELETE NO ACTION ON UPDATE NO ACTION,
     FOREIGN KEY (related_blocks) REFERENCES block (related_blocks) ON DELETE NO ACTION ON UPDATE NO ACTION,
-    FOREIGN KEY (ingredient_for_blocks) REFERENCES block (ingredient_for_blocks) ON DELETE NO ACTION ON UPDATE NO ACTION
+    FOREIGN KEY (ingredient_for_blocks) REFERENCES block (ingredient_for_blocks) ON DELETE NO ACTION ON UPDATE NO ACTION,
+    FOREIGN KEY (namespace_id) REFERENCES namespace (ingredient_for_blocks) ON DELETE CASCADE ON UPDATE CASCADE
 )`
 
 export const CREATE_NAMESPACE_TABLE = `CREATE TABLE IF NOT EXISTS namespace (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    key         TEXT    NOT NULL UNIQUE,
-    block_id    INTEGER,
-    FOREIGN KEY (block_id) REFERENCES block (block_id) ON DELETE CASCADE ON UPDATE CASCADE
+    key         TEXT    NOT NULL UNIQUE
 )`
 
 export const CREATE_GAME_VERSION_TABLE = `CREATE TABLE IF NOT EXISTS game_version (

--- a/packages/cli/src/types/shared.ts
+++ b/packages/cli/src/types/shared.ts
@@ -7,4 +7,5 @@ export const roundToInt = (num: number): Int => Math.round(num) as Int
 export type MutationResult = {
   success: boolean
   message?: string
+  data?: any
 }

--- a/packages/client/src/components/block-modal/BlockModal.tsx
+++ b/packages/client/src/components/block-modal/BlockModal.tsx
@@ -149,6 +149,7 @@ const reducer = (prevState: any, action: any) => {
         top: action.payload.top,
         left: action.payload.left,
         right: action.payload.right,
+        ...prevState,
       }
     }
     default: {
@@ -250,6 +251,20 @@ export const BlockModal = (props: {
           },
         },
       })
+      .then(() =>
+        axios.post(`http://localhost:3000/imported/block`, {
+          key: props.blockModelData.block,
+          namespace: props.namespace,
+          // TODO: set the game version using the cache once the full integration is setup
+          gameVersion: `1.12.2`,
+          title: modalState.title,
+          iconData: {
+            top: `${modalState.top}`,
+            sideL: `${modalState.left}`,
+            sideR: `${modalState.right}`,
+          },
+        })
+      )
       .then(() => props.dimiss())
   }
   /**

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import ReactDOM from "react-dom"
 import "./index.css"
 import { ConfigContentMap } from "./components/ConfigureContentMap"
+require(`dotenv`).config()
 
 ReactDOM.render(
   <React.StrictMode>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6842,6 +6842,11 @@ dotenv@8.2.0, dotenv@^8.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
+dotenv@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-9.0.2.tgz#dacc20160935a37dea6364aa1bef819fb9b6ab05"
+  integrity sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==
+
 duplexer@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
@@ -11016,7 +11021,6 @@ min-indent@^1.0.0:
     ink-spinner "^4.0.1"
     ink-text-input "^4.0.1"
     inquirer "^8.0.0"
-    lerna "^4.0.0"
     lodash "^4.17.21"
     mkdirp "^1.0.4"
     ngrok "^3.4.1"


### PR DESCRIPTION
# Description

This PR connects the Block Modal to the database by saving the configured fields to the database when the user clicks "Save". This is technically still making calls to the cache, _but caching is broken for the BlockModal after this PR_. I didn't want to spend time debugging the cache implementation, which will no longer be responsible for handling "configured" data (but will still be used for raw data).

## Testing instructions

### Adding blocks to the database
1. Start the CLI > provide a valid assets path
2. Start the web app > configure a block > _click save_ (this is what actually "commits" the data to the database)

> At the time of writing this PR, the only fields that will be **set** are `id`, `key`, `title` (if the user set a value for it), and `icon`; the remaining fields are not yet in use.

### Querying for added blocks
To test that the block data was generated as expected, simply query the endpoint:
* `GET` -> `/imported/block` 