### PR TITLE
Upsert logic for adding blocks

### DIFF
--- a/packages/cli/src/services/db/index.ts
+++ b/packages/cli/src/services/db/index.ts
@@ -317,7 +317,7 @@ export async function Dao(gameVersion?: string) {
 
       try {
         var insertBlockResult = await db.run(
-          `INSERT OR REPLACE INTO block (
+          `INSERT INTO block (
             key,
             namespace_id,
             title, 
@@ -328,7 +328,18 @@ export async function Dao(gameVersion?: string) {
             light_level, 
             min_spawn, 
             max_spawn
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+              ON CONFLICT(key) DO UPDATE SET
+                key=excluded.key,
+                namespace_id=excluded.namespace_id,
+                title=excluded.title, 
+                icon=excluded.icon, 
+                description=excluded.description, 
+                flammability_encouragement=excluded.flammability_encouragement, 
+                flammability=excluded.flammability, 
+                light_level=excluded.light_level, 
+                min_spawn=excluded.min_spawn, 
+                max_spawn=excluded.max_spawn;`,
           [
             key,
             namespaceId,

--- a/packages/client/src/components/block-modal/BlockModal.tsx
+++ b/packages/client/src/components/block-modal/BlockModal.tsx
@@ -238,33 +238,18 @@ export const BlockModal = (props: {
 
   const saveHandler = () => {
     axios
-      .post(`http://localhost:3000/content-map/blocks`, {
+      .post(`http://localhost:3000/imported/block`, {
+        key: props.blockModelData.block,
         namespace: props.namespace,
-        blocks: {
-          [props.blockModelData.block]: {
-            title: modalState.title,
-            iconData: {
-              top: `${modalState.top}`,
-              sideL: `${modalState.left}`,
-              sideR: `${modalState.right}`,
-            },
-          },
+        // TODO: set the game version using the cache once the full integration is setup
+        gameVersion: `1.12.2`,
+        title: modalState.title,
+        iconData: {
+          top: `${modalState.top}`,
+          sideL: `${modalState.left}`,
+          sideR: `${modalState.right}`,
         },
       })
-      .then(() =>
-        axios.post(`http://localhost:3000/imported/block`, {
-          key: props.blockModelData.block,
-          namespace: props.namespace,
-          // TODO: set the game version using the cache once the full integration is setup
-          gameVersion: `1.12.2`,
-          title: modalState.title,
-          iconData: {
-            top: `${modalState.top}`,
-            sideL: `${modalState.left}`,
-            sideR: `${modalState.right}`,
-          },
-        })
-      )
       .then(() => props.dimiss())
   }
   /**


### PR DESCRIPTION
# Description

Previously, I had just slapped in some code that simply replaced records with new data while I sorted out other more-pressing matters.

Now, the `addOrUpdateBlock` method actually updates existing records instead of replacing the block record (and therefore replacing the block's ID - no bueno).

This PR also completely unlinks the save logic from the cache - now, when you click save in the block modal, it _only_ saves the data to the database; nothing gets placed in the cache.