### PR TITLE
Load data for BlockModal from DB

### DIFF
--- a/packages/client/src/components/block-modal/BlockModal.tsx
+++ b/packages/client/src/components/block-modal/BlockModal.tsx
@@ -145,11 +145,8 @@ const reducer = (prevState: any, action: any) => {
     // TODO: Backend needs to be udpated to support the new fields
     case BLOCK_MODAL_ACTION.LOAD_CACHED: {
       return {
-        title: action.payload.title,
-        top: action.payload.top,
-        left: action.payload.left,
-        right: action.payload.right,
         ...prevState,
+        title: action.payload.title,
       }
     }
     default: {
@@ -208,23 +205,23 @@ export const BlockModal = (props: {
 
   // TODO: Update this once the backend supports the new fields through the cache
   useEffect(() => {
+    const version = `1.12.2`
     axios
       .get(
-        `http://localhost:3000/content-map/block?namespace=${props.namespace}&block=${props.blockModelData.block}`
+        `http://localhost:3000/imported/block?gameVersion=${version}&namespace=${props.namespace}&q=${props.blockModelData.block}`
       )
       .then((res) => {
-        const { title, iconData } = res.data
+        if (res.data && res.data.length > 0) {
+          const { title } = res.data[0]
 
-        if (title && iconData) {
-          dispatch({
-            type: BLOCK_MODAL_ACTION.LOAD_CACHED,
-            payload: {
-              title,
-              top: iconData.top,
-              left: iconData.sideL,
-              right: iconData.sideR,
-            },
-          })
+          if (title) {
+            dispatch({
+              type: BLOCK_MODAL_ACTION.LOAD_CACHED,
+              payload: {
+                title,
+              },
+            })
+          }
         }
       })
   }, [


### PR DESCRIPTION
# Description

`BlockModal` is no longer linked to the cache. Now the block data is loaded in using an API that is linked to the database.

## Testing instructions

1. Start the CLI app > specify the assets directory
2. Start the webapp > configure a block (the `BlockModal` is what renders when you click on a given block card in the list grid)
3. Save the configured block > open the same block again > the Title field should be set to whatever you saved it as before