### PR TITLE
Get (and use) cached game version

### DIFF
--- a/packages/cli/src/api/session/getCachedGameVersion.ts
+++ b/packages/cli/src/api/session/getCachedGameVersion.ts
@@ -1,0 +1,9 @@
+import express from "express"
+import { CACHE } from "../../main"
+
+export function getCachedGameVersion(
+  req: express.Request,
+  res: express.Response
+) {
+  res.send(CACHE.getCachedGameVersion())
+}

--- a/packages/cli/src/services/core/cache/index.ts
+++ b/packages/cli/src/services/core/cache/index.ts
@@ -219,21 +219,11 @@ export default class AppCache {
     return this.cache.get(KEYS.ASSETS_PATH)
   }
 
-  /**
-   * Set the game version
-   *
-   * The cached game version is how we know which database to use (or create). A database is not initialized until the
-   * user specifies where they want to import assets from. If it's a game version they have imported before, then we
-   * load the existing database so that they can review their previous configuration and optionally update if they want
-   * to.
-   *
-   * @param version
-   */
-  setGameVersion(version: string) {
+  setCachedGameVersion(version: string) {
     return this.cache.set(KEYS.GAME_VERSION, version)
   }
 
-  getGameVersion() {
+  getCachedGameVersion() {
     return this.cache.get(KEYS.GAME_VERSION)
   }
 }

--- a/packages/cli/src/services/core/server/server.ts
+++ b/packages/cli/src/services/core/server/server.ts
@@ -20,6 +20,7 @@ import { getImportedGameVersions } from "../../../api/content-map/UPDATED/getImp
 import { Dao } from "../../db"
 import { addNamespace } from "../../../api/content-map/UPDATED/addNamespace"
 import { getNamespacesFromDb } from "../../../api/content-map/UPDATED/getNamespaces"
+import { getCachedGameVersion } from "../../../api/session/getCachedGameVersion"
 
 var app = express()
 
@@ -107,6 +108,11 @@ app.post(`/content-map/export`, writeContentMapToDisk)
  * Core API routes
  *******************************************/
 app.get(`/core/imported-versions`, getImportedGameVersions)
+
+/*******************************************
+ * Session API routes
+ *******************************************/
+app.get(`/cache/game-version`, getCachedGameVersion)
 
 /*******************************************
  * Game version-specific API routes

--- a/packages/cli/src/services/minecraft/minecraftUtility.ts
+++ b/packages/cli/src/services/minecraft/minecraftUtility.ts
@@ -45,6 +45,11 @@ export class MinecraftUtility {
         ...rawNamespaceData,
       }
     })
+    const parts = args.path.split(`/`)
+    // TODO: Find out how easy it is to break this and make it less breakable (this can certainly be cleaned up)
+    // Assumes the parent directory name to the assets directory is the game version name (as is the case with base Minecraft game files)
+    const gameVersion = parts[parts.length - 2]
+    CACHE.setCachedGameVersion(gameVersion)
     CACHE.setCachedRawData(rawData)
     CACHE.setRootAssetsPath(args.path)
   }

--- a/packages/client/src/components/block-modal/BlockModal.tsx
+++ b/packages/client/src/components/block-modal/BlockModal.tsx
@@ -203,13 +203,15 @@ export const BlockModal = (props: {
       </option>
     ))
 
-  // TODO: Update this once the backend supports the new fields through the cache
   useEffect(() => {
-    const version = `1.12.2`
     axios
-      .get(
-        `http://localhost:3000/imported/block?gameVersion=${version}&namespace=${props.namespace}&q=${props.blockModelData.block}`
-      )
+      .get(`http://localhost:3000/cache/game-version`)
+      .then((response) => {
+        const gameVersion = response.data
+        return axios.get(
+          `http://localhost:3000/imported/block?gameVersion=${gameVersion}&namespace=${props.namespace}&q=${props.blockModelData.block}`
+        )
+      })
       .then((res) => {
         if (res.data && res.data.length > 0) {
           const { title } = res.data[0]
@@ -235,17 +237,20 @@ export const BlockModal = (props: {
 
   const saveHandler = () => {
     axios
-      .post(`http://localhost:3000/imported/block`, {
-        key: props.blockModelData.block,
-        namespace: props.namespace,
-        // TODO: set the game version using the cache once the full integration is setup
-        gameVersion: `1.12.2`,
-        title: modalState.title,
-        iconData: {
-          top: `${modalState.top}`,
-          sideL: `${modalState.left}`,
-          sideR: `${modalState.right}`,
-        },
+      .get(`http://localhost:3000/cache/game-version`)
+      .then((response) => {
+        const gameVersion = response.data
+        return axios.post(`http://localhost:3000/imported/block`, {
+          key: props.blockModelData.block,
+          namespace: props.namespace,
+          gameVersion,
+          title: modalState.title,
+          iconData: {
+            top: `${modalState.top}`,
+            sideL: `${modalState.left}`,
+            sideR: `${modalState.right}`,
+          },
+        })
       })
       .then(() => props.dimiss())
   }


### PR DESCRIPTION
# Description

Add an API to get the cached game version. The cached game version is set once the raw data has been successfully read in.

The `BlockModal` component now uses the new endpoint to load in the cached game version so it knows which database it should load from/save to.

## Testing instructions

You should be able to configure a block in the web app as usual, and the saved block title should populate the title field for configured blocks in the `BlockModal`