### PR TITLE
Complete block config

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "reset": "yarn clean && npm run build",
     "lint:commit": "prettier-eslint \"{src/**/*,test/**/*,packages/**/*}.{ts,tsx}\" --eslint-config-path=.eslintrc.yml --write",
     "prepare": "husky install",
+    "reset-db": "rm -rf /tmp/minecraft-asset-reader",
     "start:cli": "lerna exec --scope 'minecraft-asset-reader' yarn start",
     "build:cli": "lerna exec --scope 'minecraft-asset-reader' yarn build",
     "start:client": "lerna exec --scope 'minecraft-asset-reader-webapp' yarn start",

--- a/packages/cli/src/api/persistence/addOrUpdateBlock.ts
+++ b/packages/cli/src/api/persistence/addOrUpdateBlock.ts
@@ -23,6 +23,9 @@ export async function addOrUpdateBlock(
     lightLevel,
     minSpawn,
     maxSpawn,
+    // Harvest tools
+    harvestTool,
+    harvestToolQualities,
   } = req.body
 
   if (!key) {
@@ -56,6 +59,8 @@ export async function addOrUpdateBlock(
           iconSideTop: iconData.top,
           iconSideLeft: iconData.sideL,
           iconSideRight: iconData.sideR,
+          harvestTool,
+          harvestToolQualities,
         })
       )
       .then((result) => {

--- a/packages/cli/src/api/persistence/getHarvestToolQualitiesForBlock.ts
+++ b/packages/cli/src/api/persistence/getHarvestToolQualitiesForBlock.ts
@@ -1,0 +1,23 @@
+import express from "express"
+import { Dao } from "../../services/db"
+import { Int } from "../../types/shared"
+
+export function getHarvestToolQualitiesForBlock(
+  req: express.Request,
+  res: express.Response
+) {
+  const { gameVersion, blockId } = req.query
+
+  if (!gameVersion || !blockId) {
+    res
+      .status(422)
+      .send(`'gameVersion' and 'blockId' parameters are both required`)
+  }
+
+  Dao(gameVersion as string).then((db) =>
+    db
+      .getHarvestToolQualitiesForBlock(parseInt(blockId as string) as Int)
+      .then((result) => res.send(result))
+      .catch((e) => res.status(422).status(e))
+  )
+}

--- a/packages/cli/src/api/persistence/getHarvestToolsForBlock.ts
+++ b/packages/cli/src/api/persistence/getHarvestToolsForBlock.ts
@@ -1,0 +1,23 @@
+import express from "express"
+import { Dao } from "../../services/db"
+import { Int } from "../../types/shared"
+
+export function getHarvestToolsForBlock(
+  req: express.Request,
+  res: express.Response
+) {
+  const { gameVersion, blockId } = req.query
+
+  if (!gameVersion || !blockId) {
+    res
+      .status(422)
+      .send(`'gameVersion' and 'blockId' parameters are both required`)
+  }
+
+  Dao(gameVersion as string).then((db) =>
+    db
+      .getHarvestToolsForBlock(parseInt(blockId as string) as Int)
+      .then((result) => res.send(result))
+      .catch((e) => res.status(422).status(e))
+  )
+}

--- a/packages/cli/src/services/core/server/server.ts
+++ b/packages/cli/src/services/core/server/server.ts
@@ -21,6 +21,8 @@ import { Dao } from "../../db"
 import { getCachedGameVersion } from "../../../api/session/getCachedGameVersion"
 import { addNamespace } from "../../../api/persistence/addNamespace"
 import { getNamespacesFromDb } from "../../../api/persistence/getNamespaces"
+import { getHarvestToolsForBlock } from "../../../api/persistence/getHarvestToolsForBlock"
+import { getHarvestToolQualitiesForBlock } from "../../../api/persistence/getHarvestToolQualitiesForBlock"
 
 var app = express()
 
@@ -119,6 +121,11 @@ app.get(`/session/game-version`, getCachedGameVersion)
  *******************************************/
 // Blocks
 app.get(`/persistence/block`, getBlocks)
+app.get(`/persistence/block/harvest-tools`, getHarvestToolsForBlock)
+app.get(
+  `/persistence/block/harvest-tool-qualities`,
+  getHarvestToolQualitiesForBlock
+)
 app.post(`/persistence/block`, addOrUpdateBlock)
 app.delete(`/persistence/block`, deleteBlock)
 // Namespaces

--- a/packages/cli/src/services/db/mutations/createTables.ts
+++ b/packages/cli/src/services/db/mutations/createTables.ts
@@ -1,3 +1,15 @@
+export const CREATE_NAMESPACE_TABLE = `CREATE TABLE IF NOT EXISTS namespace (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    key         TEXT    NOT NULL UNIQUE
+)`
+
+export const CREATE_GAME_VERSION_TABLE = `CREATE TABLE IF NOT EXISTS game_version (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    key         TEXT    NOT NULL,
+    namespace_id    INTEGER,
+    FOREIGN KEY (namespace_id) REFERENCES namespace (namespace_id) ON DELETE CASCADE ON UPDATE CASCADE
+)`
+
 export const CREATE_IMPORTED_GAME_VERSION_TABLE = `CREATE TABLE IF NOT EXISTS imported_game_version (
     id      INTEGER    PRIMARY KEY AUTOINCREMENT,
     version TEXT       NOT NULL UNIQUE
@@ -13,41 +25,44 @@ export const CREATE_HARVEST_TOOL_QUALITY_TABLE = `CREATE TABLE IF NOT EXISTS har
     key TEXT       NOT NULL UNIQUE
 )`
 
-// TODO: link to items that block is component-to
 export const CREATE_BLOCK_TABLE = `CREATE TABLE IF NOT EXISTS block (
-    id                          INTEGER PRIMARY KEY AUTOINCREMENT,
-    key                         TEXT    NOT NULL UNIQUE,
-    title                       TEXT    UNIQUE,
-    icon                        TEXT,
-    icon_side_top               TEXT,
-    icon_side_left              TEXT,
-    icon_side_right             TEXT,
-    description                 TEXT,
-    flammability_encouragement  INTEGER DEFAULT 0,
-    flammability                INTEGER DEFAULT 0,
-    light_level                 INTEGER DEFAULT 0,
-    min_spawn                   INTEGER DEFAULT 0,
-    max_spawn                   INTEGER DEFAULT 0,
-    harvest_tool_id             INTEGER,
-    harvest_tool_quality_id     INTEGER,
-    related_blocks              INTEGER,
-    ingredient_for_blocks       INTEGER,
-    namespace_id                INTEGER,
-    FOREIGN KEY (harvest_tool_id) REFERENCES harvest_tool (harvest_tool_id) ON DELETE NO ACTION ON UPDATE NO ACTION,
-    FOREIGN KEY (harvest_tool_quality_id) REFERENCES harvest_tool_quality (harvest_tool_quality_id) ON DELETE NO ACTION ON UPDATE NO ACTION,
-    FOREIGN KEY (related_blocks) REFERENCES block (related_blocks) ON DELETE NO ACTION ON UPDATE NO ACTION,
-    FOREIGN KEY (ingredient_for_blocks) REFERENCES block (ingredient_for_blocks) ON DELETE NO ACTION ON UPDATE NO ACTION,
+    id                              INTEGER PRIMARY KEY AUTOINCREMENT,
+    key                             TEXT    NOT NULL UNIQUE,
+    title                           TEXT    UNIQUE,
+    icon                            TEXT,
+    icon_side_top                   TEXT,
+    icon_side_left                  TEXT,
+    icon_side_right                 TEXT,
+    description                     TEXT,
+    flammability_encouragement      INTEGER DEFAULT 0,
+    flammability                    INTEGER DEFAULT 0,
+    light_level                     INTEGER DEFAULT 0,
+    min_spawn                       INTEGER DEFAULT 0,
+    max_spawn                       INTEGER DEFAULT 0,
+    namespace_id                    INTEGER,
     FOREIGN KEY (namespace_id) REFERENCES namespace (ingredient_for_blocks) ON DELETE CASCADE ON UPDATE CASCADE
 )`
 
-export const CREATE_NAMESPACE_TABLE = `CREATE TABLE IF NOT EXISTS namespace (
-    id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    key         TEXT    NOT NULL UNIQUE
+export const CREATE_HARVEST_TOOL_TO_BLOCK_TABLE = `CREATE TABLE IF NOT EXISTS harvest_tool_to_block (
+    block_id                    INTEGER     NOT NULL,
+    harvest_tool_id             INTEGER     NOT NULL,
+    FOREIGN KEY (block_id) REFERENCES block (block_id) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (harvest_tool_id) REFERENCES harvest_tool_quality (harvest_tool_id) ON DELETE CASCADE ON UPDATE CASCADE,
+    PRIMARY KEY (block_id, harvest_tool_id)
 )`
 
-export const CREATE_GAME_VERSION_TABLE = `CREATE TABLE IF NOT EXISTS game_version (
-    id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    key         TEXT    NOT NULL,
-    namespace_id    INTEGER,
-    FOREIGN KEY (namespace_id) REFERENCES namespace (namespace_id) ON DELETE CASCADE ON UPDATE CASCADE
+export const CREATE_HARVEST_TOOL_QUALITY_TO_BLOCK_TABLE = `CREATE TABLE IF NOT EXISTS harvest_tool_quality_to_block (
+    block_id                    INTEGER     NOT NULL,
+    harvest_tool_quality_id     INTEGER     NOT NULL,
+    FOREIGN KEY (block_id) REFERENCES block (block_id) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (harvest_tool_quality_id) REFERENCES harvest_tool (harvest_tool_quality_id) ON DELETE CASCADE ON UPDATE CASCADE,
+    PRIMARY KEY (block_id, harvest_tool_quality_id)
+)`
+
+export const CREATE_BLOCK_TO_BLOCK_TABLE = `CREATE TABLE IF NOT EXISTS block_to_block (
+    block_id_a                  INTEGER     NOT NULL,
+    block_id_b                  INTEGER     NOT NULL,
+    FOREIGN KEY (block_id_a) REFERENCES block (block_id_a) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (block_id_b) REFERENCES block (block_id_a) ON DELETE CASCADE ON UPDATE CASCADE,
+    PRIMARY KEY (block_id_a, block_id_b)
 )`

--- a/packages/cli/src/types/shared.ts
+++ b/packages/cli/src/types/shared.ts
@@ -3,9 +3,14 @@ export type Int = number & { __int__: void }
 
 export const roundToInt = (num: number): Int => Math.round(num) as Int
 
-// TODO: Implement this patter for all internal APIs; need to do a lot of cleanup and standardization
 export type MutationResult = {
   success: boolean
+  id?: Int
   message?: string
   data?: any
+}
+
+export type QueryResult = {
+  id: Int
+  data: any
 }

--- a/packages/client/src/hooks/useCachedGameVersion.ts
+++ b/packages/client/src/hooks/useCachedGameVersion.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react"
+import axios from "axios"
+import { ContentMap } from "../types"
+
+export const useCachedGameVersion = () => {
+  const [gameVersion, setGameVersion] = useState({} as ContentMap)
+
+  useEffect(() => {
+    axios.get(`http://localhost:3000/session/game-version`).then((res) => {
+      setGameVersion(res.data)
+    })
+  }, [])
+
+  return gameVersion
+}


### PR DESCRIPTION
# Description

Complete the `BlockModal` by implementing to configure and save the harvest tool (and quality) for any given block. 

## Changelog
* `reset-db` script to reset the database
    * `yarn reset-db` at the project root - at the time of writing, this will only work on Unix systems - it will crap out on Windows, though we do intend to support this later
* `addOrUpdateBlock` API now handles two additional parameters:
    1. `harvestTool` - _Optional_ - `string` - The optimal tool to use for harvesting the given block
    2. `harvestToolQualities` - _Optional_ - `string[]` - The list of qualities for the harvest tool that can be used to harvest the block (e.g., Obsidian needs a pickaxe of _diamond_ quality, or better, to be harvested)
* New API endpoints (see below)
* Several database operations to facilitate the new logic (_NOTE: we will need to clean up the `Dao` in the near future - for now, it's functional)
* Standardized return values for queries and mutations from the database
    * Mutations return `MutationResult`
        * `MutationResult` now returns an optional `id` field to be used when you need to use the ID of the record you just created immediately within the parent function
    * Queries return `QueryResult` (or `QueryResult[]`)
* Added many-to-many tables for:
    * `harvest_tool_to_block`; technically allows for us to connect a block to _mulitple_ tools, but we aren't currently using it in this capacity - for now, a block can only be linked to one harvest tool via the webapp (though, it's possible to do more via the API)
    * `harvest_tool_quality_to_block` - enables blocks to be linked to multiple harvest tool qualities
    * `block_to_block` (_unused_); this will eventually be used as a template for more-specific block relationship tables (e.g., "related" and "ingredient" blocks)
* Add `useCachedGameVersion` hook (in webapp) so that we can use the game version via this hook in multiple components
    * Having it be pulled in/set via a custom hook, instead of an initialization value, allows the webapp can respond to changes in the base root assets directory (meaning the cached game version changed)
* Made all hard-coded strings lower case as a short-term fix so that they match the values stored in the database (making it easier to match up active selections)
* Use the new APIs in `BlockModal`

### New API endpoints
* `GET` - `/persistence/block/harvest-tools`
    * Parameters
        * `gameVersion` (required) - the game version of the data to be queried
        * `blockId` (required) - the internal (SQLite) ID of the block whose harvest tools to get
    * Returns `QueryResult[]`, where the `id` is the internal ID of the record and `data` is the string value for the tool (e.g., `"shovel"`)
* `GET` - `/persistence/block/harvest-tool-qualities`
    * Parameters
        * `gameVersion` (required) - the game version of the data to be queried
        * `blockId` (required) - the internal (SQLite) ID of the block whose harvest tool qualities to get
    * Returns `QueryResult[]`, where the `id` is the internal ID of the record and `data` is the string value for the quality (e.g., `"diamond"`)