### PR TITLE
Make export use DB data

### DIFF
--- a/packages/cli/src/services/core/cache/index.ts
+++ b/packages/cli/src/services/core/cache/index.ts
@@ -223,7 +223,7 @@ export default class AppCache {
     return this.cache.set(KEYS.GAME_VERSION, version)
   }
 
-  getCachedGameVersion() {
-    return this.cache.get(KEYS.GAME_VERSION)
+  getCachedGameVersion(): string {
+    return this.cache.get(KEYS.GAME_VERSION) as string
   }
 }

--- a/packages/cli/src/services/minecraft/minecraftBlockRenderer.ts
+++ b/packages/cli/src/services/minecraft/minecraftBlockRenderer.ts
@@ -1,7 +1,7 @@
-import { createCanvas, Image, loadImage } from "canvas"
-import { readFileSync, createWriteStream } from "fs"
+import { Canvas, createCanvas, Image, loadImage } from "canvas"
+import { readFileSync } from "fs"
 import { CACHE } from "../../main"
-import mkdirp from "mkdirp"
+// import mkdirp from "mkdirp"
 import { BlockIconData } from "../../types/cache"
 import { Int } from "../../types/shared"
 
@@ -168,7 +168,7 @@ export class MinecraftBlockRenderer {
     scale: number
     patternQuality: CONTEXT_PATTERN_QUALITY
     disableSmoothing?: boolean
-  }) {
+  }): Canvas {
     let scaleCanvas = createCanvas(32, 32)
     let scaleContext = scaleCanvas.getContext(`2d`)
 


### PR DESCRIPTION
# Description

Remove the (confusing-as-hell) content map and instead use the database, now that we have one, when exporting to Sanity!

For now, we are also disabling exporting to the local file system since that logic was written when the project had a completely different structure; the logic doesn't appear to be that relevant any longer (any references to code that used the "`generated`" directory probably also needs to be removed/updated)

## Changelog
* Disable File system export (the option is still in the GUI, but it's a no-op - the code has been commented out)
* Make export-to-Sanity logic use the database instead of the Content map
    * This is a necessary update as the content map is no longer used; all configured game data is stored in a game-version specific SQLite database
* Update the image scaling logic to instead scale the base icon image (instead of calling the full "draw icon" logic for each scale size)
    * This seems to have enabled us to use even larger image sizes (before, sizes over 20 or 30 simply seemed to have no effect); now, **image upload will fail for images that are too large**
        * If you hit this, you won't know about it (a fix for this will come soon, but this is all still very new) - in my testing, I know that `10` will work, but `50` will lead to the error
* Modify `getBlocks` logic so that it can accept an optional `namespaceId` argument
    * When specified, only blocks in the given namespace will be queried (if `search` is also specified, then it will search for matches within the specified namespace)
* Some quality of life typings
* Some (hopefully) useful comments - some for explaining method logic, others for simple demonstration purposes