### PR TITLE
Add default path flow

### DIFF
--- a/packages/cli/src/CLIApp.tsx
+++ b/packages/cli/src/CLIApp.tsx
@@ -11,14 +11,16 @@ import { Box } from "ink"
 import { Text } from "ink"
 import { SetAssetsPathForm } from "./components/SetAssetsPathForm"
 import { Menu } from "./components/shared/Menu"
+import { MinecraftUtility } from "../src/minecraft"
+import { SetMinecraftVersion } from "./services/core/components/SetMinecraftVersion"
+import { checkForJar } from "./utils/checkForJar"
+const minecraftAssetReader = new MinecraftUtility()
 
 export const CLIApp = () => {
   const [selectedOption, setSelectedOption] = useState(
     (null as unknown) as string
   )
-  let rawAssetsPath = useRawAssetsPath({
-    watch: selectedOption,
-  })
+  const [rawAssetsPath, setRawAssetsPath] = useState(``)
   let rawData = useRawData({
     watch: selectedOption,
   })
@@ -28,6 +30,7 @@ export const CLIApp = () => {
     rawData,
   })
 
+  const jarExists = checkForJar()
   const clearSelectedOptionHandler = () =>
     setSelectedOption((null as unknown) as string)
   const renderSelectedOptionMenu = () => {
@@ -39,6 +42,14 @@ export const CLIApp = () => {
           />
         )
       }
+      case OPTION_VALUE.USE_DEFAULT_ASSETS_DIRECTORY: {
+        return (
+          <SetMinecraftVersion
+            clearSelectedOptionHandler={clearSelectedOptionHandler}
+            setRawAssetsPathHandler={(v) => setRawAssetsPath(v)}
+          />
+        )
+      }
       default: {
         return <></>
       }
@@ -46,13 +57,6 @@ export const CLIApp = () => {
   }
   const menuSelectHandler = (option: { label: string; value: string }) => {
     // TODO: See about removing this - we probably don't need it anymore now that we rely on the webapp for most user interactions
-    // switch (option.value) {
-    //   case OPTION_VALUE.GENERATE_SITE_DATA: {
-    //     CACHE.generateSiteContent().then(() =>
-    //       setSelectedOption((null as unknown) as string)
-    //     )
-    //   }
-    // }
     // Always set the selected option, even if there is no GUI to render for the option
     setSelectedOption(option.value)
   }

--- a/packages/cli/src/CLIApp.tsx
+++ b/packages/cli/src/CLIApp.tsx
@@ -30,7 +30,6 @@ export const CLIApp = () => {
     rawData,
   })
 
-  const jarExists = checkForJar()
   const clearSelectedOptionHandler = () =>
     setSelectedOption((null as unknown) as string)
   const renderSelectedOptionMenu = () => {

--- a/packages/cli/src/components/hooks/useMenuOptions.tsx
+++ b/packages/cli/src/components/hooks/useMenuOptions.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react"
 import { RawAssetData } from "../../types/cache"
+import { checkForJar } from "../../utils"
 
 export const enum OPTION_VALUE {
   SET_ASSETS_DIRECTORY = `set_assets_directory`,
@@ -8,6 +9,7 @@ export const enum OPTION_VALUE {
   VIEW_PARSED_DATA = `view_parsed_data`,
   EXPORT_PARSED_DATA = `export_parsed_data`,
   GENERATE_SITE_DATA = `generate_site_data`,
+  USE_DEFAULT_ASSETS_DIRECTORY = `use_default_assets_directory`,
 }
 
 export const useMenuOptions = (props: {
@@ -17,7 +19,7 @@ export const useMenuOptions = (props: {
   const [options, setOptions] = useState(
     [] as { label: string; value: OPTION_VALUE }[]
   )
-
+  const jarExists = checkForJar()
   useEffect(() => {
     const array = []
     /**
@@ -30,7 +32,13 @@ export const useMenuOptions = (props: {
       label: `Set assets directory`,
       value: OPTION_VALUE.SET_ASSETS_DIRECTORY,
     })
-
+    // Only add the option to use the default directory if the jar exists
+    if (jarExists) {
+      array.push({
+        label: `Use default assets directory`,
+        value: OPTION_VALUE.USE_DEFAULT_ASSETS_DIRECTORY,
+      })
+    }
     setOptions(array)
   }, [!!props.rawData, props.rawAssetsPath])
 

--- a/packages/cli/src/services/core/components/SetMinecraftVersion.tsx
+++ b/packages/cli/src/services/core/components/SetMinecraftVersion.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect } from "react"
+import SelectInput, { Item, ItemProps } from "ink-select-input"
+import { useState } from "react"
+import { checkForAssets, detectVersions } from "../../../utils"
+import { Box, Text } from "ink"
+import { CACHE } from "../../../main"
+import { MinecraftUtility } from "../../../minecraft"
+
+const minecraftAssetReader = new MinecraftUtility()
+
+type ChoiceValue = any
+interface ChoiceOption {
+  key?: string
+  label: string
+  value: ChoiceValue
+}
+export interface Item<V> {
+  key?: string
+  label: string
+  value: V
+}
+
+export const SetMinecraftVersion = (props: {
+  clearSelectedOptionHandler: () => void
+  setRawAssetsPathHandler: (v: string) => void
+}) => {
+  const [selectedOption, setSelectedOption] = useState(
+    (null as unknown) as string
+  )
+  const clearSelectedOptionHandler = () =>
+    setSelectedOption((null as unknown) as string)
+  const [minecraftVersions, setMinecraftVersions] = useState()
+  const [selectedVersion, setSelectedVersion] = useState(``)
+
+  const selectHandler = (value: any) => {
+    setSelectedVersion(value)
+    if (value) {
+      props.clearSelectedOptionHandler()
+    }
+  }
+
+  // TODO: Find out why there's a memory leak in this component. It's probably in useEffect().
+  useEffect(() => {
+    let isMounted = true
+    let minecraftVersionsArray: any
+
+    detectVersions()
+      .then((v) => (minecraftVersionsArray = v))
+      .then(() => {
+        setMinecraftVersions(minecraftVersionsArray)
+      })
+
+    checkForAssets(selectedVersion, { clearSelectedOptionHandler }).then(
+      (path) => {
+        if (path) {
+          minecraftAssetReader.readInRawData({
+            path,
+          })
+          CACHE.setRootAssetsPath(path)
+          props.setRawAssetsPathHandler(path)
+        } else {
+          console.error(`path did not exist when passed to readInRawData`)
+        }
+      }
+    )
+  }, [selectedVersion, minecraftVersions])
+
+  return (
+    <>
+      <Box>
+        <Text>Select the Minecraft version you want to use: </Text>
+      </Box>
+      {!!minecraftVersions ? (
+        <SelectInput
+          items={minecraftVersions}
+          onSelect={(item) => selectHandler(item)}
+        />
+      ) : (
+        <Text>...</Text>
+      )}
+    </>
+  )
+}

--- a/packages/cli/src/services/core/components/SetMinecraftVersion.tsx
+++ b/packages/cli/src/services/core/components/SetMinecraftVersion.tsx
@@ -49,20 +49,21 @@ export const SetMinecraftVersion = (props: {
       .then(() => {
         setMinecraftVersions(minecraftVersionsArray)
       })
-
-    checkForAssets(selectedVersion, { clearSelectedOptionHandler }).then(
-      (path) => {
-        if (path) {
-          minecraftAssetReader.readInRawData({
-            path,
-          })
-          CACHE.setRootAssetsPath(path)
-          props.setRawAssetsPathHandler(path)
-        } else {
-          console.error(`path did not exist when passed to readInRawData`)
-        }
-      }
-    )
+      .then(() => {
+        checkForAssets(selectedVersion, { clearSelectedOptionHandler }).then(
+          (path) => {
+            if (path) {
+              minecraftAssetReader.readInRawData({
+                path,
+              })
+              CACHE.setRootAssetsPath(path)
+              props.setRawAssetsPathHandler(path)
+            } else {
+              console.error(`path did not exist when passed to readInRawData`)
+            }
+          }
+        )
+      })
   }, [selectedVersion, minecraftVersions])
 
   return (

--- a/packages/cli/src/utils/checkForDefaultAssetsDir.ts
+++ b/packages/cli/src/utils/checkForDefaultAssetsDir.ts
@@ -1,0 +1,111 @@
+const fs = require(`fs`)
+const os = require(`os`)
+const systemUser = os.userInfo().username
+import { extractJar } from "./index"
+
+let defaultDir = ``
+const currentOs = os.type()
+
+/**
+ *
+ * @param selectedVersion
+ * @param props
+ * @returns defaultDir or fallbackDefaultDir
+ *
+ * checkForAssets() gets the current operating system (OS),
+ * then checks if the default assets directory for the OS
+ * exists. If it doesn't exist, it tries to find the default Minecraft
+ * Jar file. if the Jar file exists, it extracts it (creating the default
+ * assets directory). In either case, the result is that it
+ * returns the default assets directory based on the current OS.
+ */
+
+// TODO: Add logic to handle if the Jar file doesn't exist
+// TODO: If it falls through or fails, return to the main menu.
+
+export async function checkForAssets(
+  selectedVersion: any,
+  props: {
+    clearSelectedOptionHandler: () => void
+  }
+) {
+  const fallbackDefaultDir = `/home/${systemUser}/.minecraft/versions/1.12.2/assets`
+  const linuxJar = `/home/${systemUser}/.minecraft/versions/${selectedVersion.value}/${selectedVersion.value}.jar`
+  const darwinJar = `~/Library/Application Support/minecraft/versions/${selectedVersion.value}/${selectedVersion.value}.jar`
+  const winJar = `%appdata%\\.minecraft\\versions\\${selectedVersion.value}\\${selectedVersion.value}.jar`
+  const linuxAssets = `/home/${systemUser}/.minecraft/versions/${selectedVersion.value}/assets`
+  const darwinAssets = `~/Library/Application Support/minecraft/versions/${selectedVersion.value}/assets`
+  const winAssets = `%appdata%\\.minecraft\\versions\\${selectedVersion.value}\\assets`
+  const linuxExportDir = `/home/${systemUser}/.minecraft/versions/${selectedVersion.value}/`
+  const darwinExportDir = `~/Library/Application Support/minecraft/versions/${selectedVersion.value}/`
+  const winExportDir = `%appdata%\\.minecraft\\versions\\${selectedVersion.value}\\`
+  let os: string = currentOs
+
+  switch (os) {
+    case `Linux`:
+      try {
+        if (fs.existsSync(linuxAssets)) {
+          defaultDir = linuxAssets
+          console.log(`Assets directory exists: `, linuxAssets)
+        } else {
+          console.log(`Assets directory does not exist. \nExtracting jar...`)
+          await extractJar(linuxJar, linuxExportDir)
+          defaultDir = linuxAssets
+        }
+      } catch (e) {
+        console.log(
+          `An error occurred while checking for the assets directory.`
+        )
+      }
+      break
+    case `Darwin`:
+      try {
+        if (fs.existsSync(darwinAssets)) {
+          console.log(`Assets directory exists: `, darwinAssets)
+          defaultDir = darwinAssets
+          return defaultDir
+        } else {
+          console.log(`Assets directory does not exist. \nExtracting jar...`)
+          extractJar(darwinJar, darwinExportDir)
+          defaultDir = darwinAssets
+          return defaultDir
+        }
+      } catch (e) {
+        console.log(
+          `An error occurred while checking for the assets directory.`
+        )
+      }
+      break
+    case `Windows_NT`:
+      try {
+        if (fs.existsSync(winAssets)) {
+          console.log(`Assets directory exists: `, winAssets)
+          defaultDir = winAssets
+          return defaultDir
+        } else {
+          console.log(`Assets directory does not exist. \nExtracting jar...`)
+          extractJar(winJar, winExportDir)
+          defaultDir = winAssets
+          return defaultDir
+        }
+      } catch (e) {
+        console.log(
+          `An error occurred while checking for the assets directory.`
+        )
+      }
+      break
+    default:
+      console.log(`Fell through to default case`)
+  }
+  if (selectedVersion) {
+    return defaultDir
+  } else {
+    //  TODO: Instead of using a fallback directory, redirect the user to the main prompt.
+
+    console.log(
+      `selectedVersion is empty, using fallbackDefaultDir: `,
+      fallbackDefaultDir
+    )
+    return fallbackDefaultDir
+  }
+}

--- a/packages/cli/src/utils/checkForJar.ts
+++ b/packages/cli/src/utils/checkForJar.ts
@@ -1,0 +1,90 @@
+const fs = require(`fs`)
+const os = require(`os`)
+const { join } = require(`path`)
+const systemUser = os.userInfo().username
+
+let jarDir = ``
+let jarExists = false
+
+export interface Item<V> {
+  key?: string
+  label: string
+  value: V
+}
+
+const currentOs = os.type()
+const minecraftVersion = `1.12.2`
+
+const linuxJar = `/home/${systemUser}/.minecraft/versions/${minecraftVersion}/${minecraftVersion}.jar`
+const darwinJar = `~/Library/Application Support/minecraft/versions/${minecraftVersion}/${minecraftVersion}.jar`
+const winJar = `%appdata%\\.minecraft\\versions\\${minecraftVersion}\\${minecraftVersion}.jar`
+
+export function checkForJar() {
+  let os: any = currentOs
+  switch (os) {
+    case `Linux`:
+      try {
+        if (fs.existsSync(linuxJar)) {
+          jarDir = linuxJar
+
+          jarExists = true
+        } else {
+          console.error(
+            `Minecraft jar for version ${minecraftVersion} does not exist.`
+          )
+          jarExists = false
+        }
+      } catch (e) {
+        console.error(
+          `An error occurred while checking for the Minecraft jar for version ${minecraftVersion}.`,
+          e
+        )
+        jarExists = false
+      }
+      break
+    case `Darwin`:
+      try {
+        if (fs.existsSync(darwinJar)) {
+          jarDir = darwinJar
+          jarExists = true
+        } else {
+          console.error(
+            `Minecraft jar for version ${minecraftVersion} does not exist.`
+          )
+          jarExists = false
+        }
+      } catch (e) {
+        console.error(
+          `An error occurred while checking for the Minecraft jar for version ${minecraftVersion}.`,
+          e
+        )
+        jarExists = false
+      }
+      break
+    case `Windows_NT`:
+      try {
+        if (fs.existsSync(winJar)) {
+          jarDir = winJar
+          jarExists = true
+        } else {
+          console.error(
+            `Minecraft  jar for version ${minecraftVersion} does not exist.`
+          )
+          jarExists = false
+        }
+      } catch (e) {
+        console.error(
+          `An error occurred while checking for the Minecraft jar for version ${minecraftVersion}.`,
+          e
+        )
+        jarExists = false
+      }
+      break
+    default:
+      console.log(
+        `Fell through to default when checking for Minecraft jar for version ${minecraftVersion}.`
+      )
+      jarExists = false
+  }
+  return jarExists
+}

--- a/packages/cli/src/utils/detectLocalVersions.ts
+++ b/packages/cli/src/utils/detectLocalVersions.ts
@@ -1,0 +1,133 @@
+const fs = require(`fs`)
+const os = require(`os`)
+const systemUser = os.userInfo().username
+
+type ChoiceValue = any
+interface ChoiceOption {
+  key?: string
+  label: string
+  value: ChoiceValue
+}
+
+let versionsDir = ``
+let versionsArray: ChoiceOption[] = []
+
+const currentOs = os.type()
+
+const linuxVersions = `/home/${systemUser}/.minecraft/versions/`
+const darwinVersions = `~/Library/Application Support/minecraft/versions/`
+const winVersions = `%appdata%\\.minecraft\\versions\\`
+
+export async function detectVersions() {
+  let os: any = currentOs
+  switch (os) {
+    case `Linux`:
+      try {
+        if (fs.existsSync(linuxVersions)) {
+          versionsDir = linuxVersions
+          try {
+            const installations = fs.readdirSync(versionsDir)
+            for (const version of installations) {
+              if (
+                version.match(/([1-9]\.[1-9])/g) &&
+                !versionsArray.find((v: any) => v.value === version)
+              ) {
+                let versionOption = {
+                  label: `${version}`,
+                  value: `${version}`,
+                }
+                versionsArray.push(versionOption)
+              }
+            }
+            return versionsArray
+          } catch (e) {
+            console.error(e)
+          }
+          console.log(`Found Minecraft installations: `, linuxVersions)
+        } else {
+          console.log(`Minecraft installations directory does not exist.`)
+
+          versionsDir = linuxVersions
+        }
+      } catch (e) {
+        console.log(
+          `An error occurred while checking for the Minecraft installations directory.`,
+          e
+        )
+      }
+      break
+    case `Darwin`:
+      try {
+        if (fs.existsSync(darwinVersions)) {
+          versionsDir = darwinVersions
+          try {
+            const installations = fs.readdirSync(versionsDir)
+            for (const version of installations) {
+              if (
+                version.match(/([1-9]\.[1-9])/g) &&
+                !versionsArray.find((v: any) => v.value === version)
+              ) {
+                let versionOption = {
+                  label: `${version}`,
+                  value: `${version}`,
+                }
+                versionsArray.push(versionOption)
+              }
+            }
+            return versionsArray
+          } catch (e) {
+            console.error(e)
+          }
+          console.log(`Found Minecraft installations: `, darwinVersions)
+        } else {
+          console.log(`Minecraft installations directory does not exist.`)
+
+          versionsDir = darwinVersions
+        }
+      } catch (e) {
+        console.log(
+          `An error occurred while checking for the Minecraft installations directory.`,
+          e
+        )
+      }
+      break
+    case `Windows_NT`:
+      try {
+        if (fs.existsSync(winVersions)) {
+          versionsDir = winVersions
+          try {
+            const installations = fs.readdirSync(versionsDir)
+            for (const version of installations) {
+              if (
+                version.match(/([1-9]\/.[1-9])/g) &&
+                !versionsArray.find((v: any) => v.value === version)
+              ) {
+                let versionOption = {
+                  label: `${version}`,
+                  value: `${version}`,
+                }
+                versionsArray.push(versionOption)
+              }
+            }
+            return versionsArray
+          } catch (e) {
+            console.error(e)
+          }
+          console.log(`Found Minecraft installations: `, winVersions)
+        } else {
+          console.log(`Minecraft installations directory does not exist.`)
+
+          versionsDir = winVersions
+        }
+      } catch (e) {
+        console.log(
+          `An error occurred while checking for the Minecraft installations directory.`,
+          e
+        )
+      }
+      break
+    default:
+      console.log(`Fell through to default`)
+  }
+  return versionsArray
+}

--- a/packages/cli/src/utils/extractJar.ts
+++ b/packages/cli/src/utils/extractJar.ts
@@ -1,0 +1,29 @@
+import unzipper from "unzipper"
+import { createReadStream, existsSync } from "fs"
+
+/**
+ * extractJar(path, exportPath) accepts a file path to a .jar file
+ * and a path to extract the .jar into. It extracts the .jar, then returns a promise.
+ *
+ * @param path
+ * @param exportPath
+ * @returns
+ */
+export async function extractJar(path: any, exportPath: any) {
+  /**
+   * An alternative way to extract a .jar file is to use:
+   * `createReadStream(path).pipe(unzipper.Extract({ path: exportPath}))`
+   */
+
+  try {
+    if (existsSync(path)) {
+      return unzipper.Open.file(path).then((d) =>
+        d.extract({ path: exportPath })
+      )
+    } else {
+      console.log(`The Jar file doesn't exist.`)
+    }
+  } catch (e) {
+    console.log(`An error occurred while checking for the Jar file.`)
+  }
+}

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -1,0 +1,4 @@
+export * from "./checkForDefaultAssetsDir"
+export * from "./checkForJar"
+export * from "./detectLocalVersions"
+export * from "./extractJar"


### PR DESCRIPTION
See issue #73 

Add the logic and components required to support a "default path" flow where the user is able to select "use default path" instead of manually entering the Minecraft assets directory. 

Once the user selects the "use default path" option, the minecraft-asset-reader tool will check the default installation directory (for the user's operating system) for Minecraft installations. If it finds one or more, it will list them as options. The user can then select one of the options. 

### Additional logic:
- If the Minecraft installation directory only has `.jar` files, the tool will extract the `.jar` files. 
- If a Minecraft assets directory namespace doesn't have a recognized directory structure, the tool will skip it during the asset import. An example of such a scenario is the `realms` namespace in Minecraft version 1.16.5. 

### Utility functions:
To support the "use default path" user flow, the PR should also add the following utilities:
- **`checkForJar()`** -- A utility function that detects if the Minecraft installation version `.jar` file exists in the default location for the user's operating system. 
- **`checkForDefaultAssetsDir(selectedVersion)`** -- A utility function that checks for the `.jar` file of the selected Minecraft version in the default location for the user's operating system. It depends on `checkForJar()`. 
- **`detectLocalVersions`** -- A utility function that detects all Minecraft versions installed on the user's system. 
- **`extractJar(path, exportPath)`** -- A utility function that extracts the `.jar` file `path` into `exportPath`. 