### PR TITLE
Move SetMinecraftVersion to components

### DIFF
--- a/packages/cli/src/CLIApp.tsx
+++ b/packages/cli/src/CLIApp.tsx
@@ -6,7 +6,7 @@ import { Box } from "ink"
 import { Text } from "ink"
 import { SetAssetsPathForm } from "./components/SetAssetsPathForm"
 import { Menu } from "./components/shared/Menu"
-import { SetMinecraftVersion } from "./services/core/components/SetMinecraftVersion"
+import { SetMinecraftVersion } from "./components/SetMinecraftVersion"
 
 export const CLIApp = () => {
   const [selectedOption, setSelectedOption] = useState(


### PR DESCRIPTION
# Description

Move `SetMinecraftVersion` to the new location (seems like some weirdness happened on a previous merge conflict). Additionally, prevent setting state when component is unmounted.