### PR TITLE
Remove block description field

### DIFF
--- a/packages/cli/src/api/persistence/addOrUpdateBlock.ts
+++ b/packages/cli/src/api/persistence/addOrUpdateBlock.ts
@@ -14,7 +14,6 @@ export async function addOrUpdateBlock(
     icon,
     // When iconData is provided, the icon will be set/updated using the given texture info
     iconData,
-    description,
     flammabilityEncouragementValue,
     flammability,
     lightLevel,
@@ -46,7 +45,6 @@ export async function addOrUpdateBlock(
           namespace,
           title,
           icon,
-          description,
           flammabilityEncouragementValue,
           flammability,
           lightLevel,

--- a/packages/cli/src/db/index.ts
+++ b/packages/cli/src/db/index.ts
@@ -280,7 +280,6 @@ export async function Dao(gameVersion?: string) {
      * @param key
      * @param title
      * @param icon
-     * @param description
      * @param flammabilityEncouragementValue
      * @param flammability
      * @param lightLevel
@@ -295,7 +294,6 @@ export async function Dao(gameVersion?: string) {
       iconSideTop?: string
       iconSideLeft?: string
       iconSideRight?: string
-      description?: string
       flammabilityEncouragementValue?: Int
       flammability?: Int
       lightLevel?: Int
@@ -309,7 +307,6 @@ export async function Dao(gameVersion?: string) {
         namespace,
         title,
         icon,
-        description,
         flammabilityEncouragementValue,
         flammability,
         lightLevel,
@@ -392,7 +389,6 @@ export async function Dao(gameVersion?: string) {
             namespace_id,
             title, 
             icon, 
-            description, 
             flammability_encouragement, 
             flammability, 
             light_level, 
@@ -401,13 +397,12 @@ export async function Dao(gameVersion?: string) {
             icon_side_top,
             icon_side_left,
             icon_side_right
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
               ON CONFLICT(key) DO UPDATE SET
                 key=excluded.key,
                 namespace_id=excluded.namespace_id,
                 title=excluded.title, 
                 icon=excluded.icon, 
-                description=excluded.description, 
                 flammability_encouragement=excluded.flammability_encouragement, 
                 flammability=excluded.flammability, 
                 light_level=excluded.light_level, 
@@ -421,7 +416,6 @@ export async function Dao(gameVersion?: string) {
             namespaceId,
             title,
             icon,
-            description,
             flammabilityEncouragementValue,
             flammability,
             lightLevel,

--- a/packages/cli/src/db/mutations/createTables.ts
+++ b/packages/cli/src/db/mutations/createTables.ts
@@ -33,7 +33,6 @@ export const CREATE_BLOCK_TABLE = `CREATE TABLE IF NOT EXISTS block (
     icon_side_top                   TEXT,
     icon_side_left                  TEXT,
     icon_side_right                 TEXT,
-    description                     TEXT,
     flammability_encouragement      INTEGER DEFAULT 0,
     flammability                    INTEGER DEFAULT 0,
     light_level                     INTEGER DEFAULT 0,

--- a/packages/client/src/components/block-modal/BlockModal.tsx
+++ b/packages/client/src/components/block-modal/BlockModal.tsx
@@ -85,12 +85,6 @@ const reducer = (prevState: any, action: any) => {
         right: action.payload.right,
       }
     }
-    case BLOCK_MODAL_ACTION.SET_DESCRIPTION: {
-      return {
-        ...prevState,
-        description: action.payload.description,
-      }
-    }
     case BLOCK_MODAL_ACTION.SET_FLAMMABILITY: {
       return {
         ...prevState,
@@ -150,7 +144,6 @@ const reducer = (prevState: any, action: any) => {
         top: action.payload.top,
         left: action.payload.left,
         right: action.payload.right,
-        description: action.payload.description,
         flammabilityEncouragement: action.payload.flammabilityEncouragement,
         flammability: action.payload.flammability,
         lightLevel: action.payload.lightLevel,
@@ -190,7 +183,6 @@ export const BlockModal = (props: {
     top: NONE,
     left: NONE,
     right: NONE,
-    description: ``,
     flammabilityEncouragement: 0,
     flammability: 0,
     lightLevel: 0,
@@ -228,7 +220,6 @@ export const BlockModal = (props: {
             icon_side_top,
             icon_side_left,
             icon_side_right,
-            description,
             flammability_encouragement,
             flammability,
             light_level,
@@ -246,7 +237,6 @@ export const BlockModal = (props: {
                 top: icon_side_top,
                 left: icon_side_left,
                 right: icon_side_right,
-                description,
                 flammabilityEncouragement: flammability_encouragement,
                 flammability,
                 lightLevel: light_level,
@@ -284,7 +274,6 @@ export const BlockModal = (props: {
           sideL: `${modalState.left}`,
           sideR: `${modalState.right}`,
         },
-        description: modalState.description,
         flammabilityEncouragementValue: modalState.flammabilityEncouragement,
         flammability: modalState.flammability,
         lightLevel: modalState.lightLevel,
@@ -445,21 +434,6 @@ export const BlockModal = (props: {
         <br />
         <div className="mx-2">
           <h2 className="text-xl font-bold">Block data</h2>
-          <div className="text-center">
-            <textarea
-              className="modal-input w-4/5 h-24 align-top"
-              placeholder="Block description"
-              value={modalState.description}
-              onChange={(e) =>
-                dispatch({
-                  type: BLOCK_MODAL_ACTION.SET_DESCRIPTION,
-                  payload: {
-                    description: e.target.value,
-                  },
-                })
-              }
-            />
-          </div>
           <BlockModalNumberInput
             label="Light Level"
             value={modalState.lightLevel}


### PR DESCRIPTION
# Description

We were previously exposing a "description" field in the Block modal. The idea was to provide the user with a way to set some description text to start with. However, given that the schema for the `description` field in the `minecraftBlock` type of the Minecraft Blog Starter is _NOT_ a simple text field, but rather an array of text blocks, it seems much easier to simply drop the description field on our end entirely and rely on Sanity for the content-heavy fields such as this one.

Since the end goal of this entire project is to make it easier for the user to _create_ the site starter content (not "maintain" it), we should opt to expose "data" fields on our end, and leave the more subjective ones up to Sanity as text blocks (or some other form of rich content).