### PR TITLE
Remove generated directory logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "minecraft-asset-reader": "bin/script.sh"
   },
   "scripts": {
-    "clean": "rm -rf out/ generated/ dist/",
+    "clean": "rm -rf out/ dist/",
     "reset": "yarn clean && npm run build",
     "lint:commit": "prettier-eslint \"{src/**/*,test/**/*,packages/**/*}.{ts,tsx}\" --eslint-config-path=.eslintrc.yml --write",
     "prepare": "husky install",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "clean": "rm -rf out/ generated/ dist/",
+    "clean": "rm -rf out/ dist/",
     "reset": "yarn clean && npm run build",
     "lint:commit": "prettier-eslint \"{src/**/*,test/**/*,packages/**/*}.{ts,tsx}\" --eslint-config-path=.eslintrc.yml --write",
     "test": "jest --verbose=false",

--- a/packages/cli/src/cache/index.ts
+++ b/packages/cli/src/cache/index.ts
@@ -3,7 +3,6 @@ import {
   CONTEXT_PATTERN_QUALITY,
   MinecraftBlockRenderer,
 } from "../minecraft/minecraftBlockRenderer"
-import mkdirp from "mkdirp"
 import { loadImage } from "canvas"
 import { RawAssetData } from "../types/cache"
 import { Int } from "../types/shared"
@@ -94,8 +93,6 @@ export default class AppCache {
     const scaledTextures = {} as {
       [key: string]: string
     }
-
-    await mkdirp(`./generated/scaled_images`)
 
     await Promise.all(
       Object.keys(rawBlockData.textures!).map(async (textureKey) => {

--- a/packages/cli/src/minecraft/minecraftBlockRenderer.ts
+++ b/packages/cli/src/minecraft/minecraftBlockRenderer.ts
@@ -71,15 +71,10 @@ export class MinecraftBlockRenderer {
     // The texture names (not the actual textures, yet)
     const { top, sideL, sideR } = args.blockIconData
     const { scale, namespace } = args
-    let { writePath } = args
 
     let scaleValue = 16
     if (!!scale) {
       scaleValue = scale
-    }
-
-    if (!writePath) {
-      writePath = `./generated/export`
     }
 
     const rawAssetsPath = await CACHE.getRootAssetsPath()


### PR DESCRIPTION
# Description

We used to create a generated directory as a temporary location to hold images. This was one of those "quick and dirty" solutions we implemented just to see the icon generation logic. Since we have long since gotten past that point, it's time to remove the generated directory logic.

