### PR TITLE
Expose link to webapp in built code

### DIFF
--- a/packages/cli/src/CLIApp.tsx
+++ b/packages/cli/src/CLIApp.tsx
@@ -6,6 +6,7 @@ import { Box, Text } from "ink"
 import { SetAssetsPathForm } from "./components/SetAssetsPathForm"
 import { Menu } from "./components/shared/Menu"
 import { SetMinecraftVersion } from "./components/SetMinecraftVersion"
+import open from "open"
 
 export const CLIApp = () => {
   const [selectedOption, setSelectedOption] = useState(
@@ -39,6 +40,10 @@ export const CLIApp = () => {
             setRawAssetsPathHandler={(v) => setRawAssetsPath(v)}
           />
         )
+      }
+      // This option is only visible when LOCAL is false (e.g., when running the built app, instead of running the CLI and webapp separately)
+      case OPTION_VALUE.OPEN_WEBAPP: {
+        open(`http://localhost:3000`).then(() => clearSelectedOptionHandler())
       }
       default: {
         return <></>

--- a/packages/cli/src/components/hooks/useMenuOptions.tsx
+++ b/packages/cli/src/components/hooks/useMenuOptions.tsx
@@ -10,6 +10,7 @@ export const enum OPTION_VALUE {
   EXPORT_PARSED_DATA = `export_parsed_data`,
   GENERATE_SITE_DATA = `generate_site_data`,
   USE_DEFAULT_ASSETS_DIRECTORY = `use_default_assets_directory`,
+  OPEN_WEBAPP = `open_webapp`,
 }
 
 export const useMenuOptions = (props: {
@@ -37,6 +38,13 @@ export const useMenuOptions = (props: {
       array.push({
         label: `Use default assets directory`,
         value: OPTION_VALUE.USE_DEFAULT_ASSETS_DIRECTORY,
+      })
+    }
+
+    if (!process.env.LOCAL) {
+      array.push({
+        label: `Open webapp`,
+        value: OPTION_VALUE.OPEN_WEBAPP,
       })
     }
     setOptions(array)


### PR DESCRIPTION
# Description

Now that we have a way to build the entire app, we can start serving up the built webapp code. This is _technically_ also possible to do with the TypeScript code, but I'd rather not slap the `build` directory into the source code area. It seems much cleaner to just keep all of the built code together.

With that said, if you run `yarn build-app`, then `yarn run-app`, you'll see a new menu option, `Open webapp`, which simply opens a browser tab on the webapp (`http://localhost:3000/`)

This pretty much rounds out the full end-to-end functionality of the app. All that's left now is to make it run as a standalone CLI. We obviously have much more in the way of features, but the core architecture for this application is reaching a good final "Version 1" (or more-likely, a beta... :sweat_smile: ) starting point.