### PR TITLE
Remove FS as export option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,11 @@ yarn run-app
      - _Create a custom "minecraft asset reader" Sanity studio and use it during the bootstrap process_
      - With this flow, you won't need to download or generate any schema files - simply give the starter the requisite types
      - Admittedly, this isn't as easy as simply setting up a project with content types (e.g., as Contentful, Flotiq, and many others allow)
+
+## Dependency notes
+
+This section contains information about specific cases where there is "a reason" behind why we are using a specific dependency (or version of a dependency). \_This is not a comprehensive list of dependencies used in this project, but rather explanations about how we handled various Dependabot alerts (among other things).
+
+1. **PostCSS** - `^7` - _this version has a moderate vulnerability and it's recommended we update to `>=8.2.10`_
+   - We can't easily fix this as it's a problem with `create-react-app`, which does not work with version 8
+   - See: https://github.com/postcss/postcss/wiki/PostCSS-8-for-end-users

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "minecraft-asset-reader"
   ],
   "scripts": {
-    "clean": "rm -rf out/ dist/",
-    "reset": "yarn clean && npm run build",
+    "clean": "rm -rf out/ dist/ node_modules packages/cli/node_modules packages/client/node_modules",
+    "reset": "yarn clean && yarn && yarn lerna bootstrap && cd packages/cli && yarn && cd ../client && yarn",
     "lint:commit": "prettier-eslint \"{src/**/*,test/**/*,packages/**/*}.{ts,tsx}\" --eslint-config-path=.eslintrc.yml --write",
     "prepare": "husky install",
     "reset-db": "rm -rf /tmp/minecraft-asset-reader",

--- a/packages/client/src/components/ExportConfirmationModal.tsx
+++ b/packages/client/src/components/ExportConfirmationModal.tsx
@@ -7,9 +7,7 @@ export const ExportConfirmationModal = (props: {
   cancelHandler: () => void
 }) => {
   const [blockScaleSizes, setBlockScaleSizes] = useState([1])
-  const [exportLocation, setExportLocation] = useState(
-    EXPORT_LOCATION.FILE_SYSTEM
-  )
+  const [exportLocation, setExportLocation] = useState(EXPORT_LOCATION.SANITY)
   const [writePath, setWritePath] = useState(``)
   const [projectId, setProjectId] = useState(``)
   const [dataset, setDataset] = useState(``)
@@ -24,18 +22,18 @@ export const ExportConfirmationModal = (props: {
     setLoading(true)
     // TODO: Start a loading spinner
     switch (exportLocation) {
-      case EXPORT_LOCATION.FILE_SYSTEM: {
-        axios
-          .post(`http://localhost:3000/site-data/export`, {
-            writePath,
-            blockIconScaleSizes: blockScaleSizes,
-          })
-          .then(() => {
-            setLoading(false) // TODO: May not even need this since we are about to dismiss the modal
-            props.cancelHandler()
-          })
-        break
-      }
+      // case EXPORT_LOCATION.FILE_SYSTEM: {
+      //   axios
+      //     .post(`http://localhost:3000/site-data/export`, {
+      //       writePath,
+      //       blockIconScaleSizes: blockScaleSizes,
+      //     })
+      //     .then(() => {
+      //       setLoading(false) // TODO: May not even need this since we are about to dismiss the modal
+      //       props.cancelHandler()
+      //     })
+      //   break
+      // }
       case EXPORT_LOCATION.SANITY: {
         axios
           .post(`http://localhost:3000/site-data/export/sanity`, {
@@ -136,17 +134,6 @@ export const ExportConfirmationModal = (props: {
                 </li>
               ))}
             </ul>
-            {exportLocation === EXPORT_LOCATION.FILE_SYSTEM ? (
-              <label>
-                Export path:
-                <input
-                  className="export-modal-input"
-                  type="input"
-                  placeholder="..."
-                  onChange={(e) => setWritePath(e.target.value)}
-                />
-              </label>
-            ) : null}
             {exportLocation === EXPORT_LOCATION.SANITY ? (
               <div className="flex flex-col">
                 <label>

--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -1,4 +1,3 @@
 export enum EXPORT_LOCATION {
-  FILE_SYSTEM = `fs`,
   SANITY = `sanity`,
 }

--- a/packages/client/yarn.lock
+++ b/packages/client/yarn.lock
@@ -2341,7 +2341,7 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
-"@tailwindcss/postcss7-compat@^2.1.2", "tailwindcss@npm:@tailwindcss/postcss7-compat":
+"@tailwindcss/postcss7-compat@^2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@tailwindcss/postcss7-compat/-/postcss7-compat-2.1.2.tgz#4ae2a3a3c05622ee04307997b0f8bea5c8dbc2b6"
   integrity sha512-bH2kw6uyqLnDMP8wzDUsis5ovrsRzfHEyiL1McADvqlW54g6y0KVHX1xzO7PH8Fl5s0Sq8vDOAp4+3V8MEcZ9g==
@@ -12033,6 +12033,41 @@ table@^6.0.9:
     slice-ansi "^4.0.0"
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
+
+"tailwindcss@npm:@tailwindcss/postcss7-compat":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/postcss7-compat/-/postcss7-compat-2.1.4.tgz#427a2fd1837a3d9a54a296cc8b86a3f76b1452a7"
+  integrity sha512-KYRj/AGNwE4tPf02IvT+J36Twlrwg/OJJuSckSupX2T+xIOHSXPugNJZ7Stn9F67hh/qH+2Y2HXK6vpBadW6qw==
+  dependencies:
+    "@fullhuman/postcss-purgecss" "^3.1.3"
+    autoprefixer "^9"
+    bytes "^3.0.0"
+    chalk "^4.1.0"
+    chokidar "^3.5.1"
+    color "^3.1.3"
+    detective "^5.2.0"
+    didyoumean "^1.2.1"
+    dlv "^1.1.3"
+    fast-glob "^3.2.5"
+    fs-extra "^9.1.0"
+    html-tags "^3.1.0"
+    lodash "^4.17.21"
+    lodash.topath "^4.5.2"
+    modern-normalize "^1.0.0"
+    node-emoji "^1.8.1"
+    normalize-path "^3.0.0"
+    object-hash "^2.1.1"
+    parse-glob "^3.0.4"
+    postcss "^7"
+    postcss-functions "^3"
+    postcss-js "^2"
+    postcss-nested "^4"
+    postcss-selector-parser "^6.0.4"
+    postcss-value-parser "^4.1.0"
+    pretty-hrtime "^1.0.3"
+    quick-lru "^5.1.1"
+    reduce-css-calc "^2.1.8"
+    resolve "^1.20.0"
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3211,7 +3211,7 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
-"@tailwindcss/postcss7-compat@^2.1.2", "tailwindcss@npm:@tailwindcss/postcss7-compat":
+"@tailwindcss/postcss7-compat@^2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@tailwindcss/postcss7-compat/-/postcss7-compat-2.1.2.tgz#4ae2a3a3c05622ee04307997b0f8bea5c8dbc2b6"
   integrity sha512-bH2kw6uyqLnDMP8wzDUsis5ovrsRzfHEyiL1McADvqlW54g6y0KVHX1xzO7PH8Fl5s0Sq8vDOAp4+3V8MEcZ9g==
@@ -15584,6 +15584,41 @@ table@^6.0.4:
     slice-ansi "^4.0.0"
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
+
+"tailwindcss@npm:@tailwindcss/postcss7-compat":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/postcss7-compat/-/postcss7-compat-2.1.4.tgz#427a2fd1837a3d9a54a296cc8b86a3f76b1452a7"
+  integrity sha512-KYRj/AGNwE4tPf02IvT+J36Twlrwg/OJJuSckSupX2T+xIOHSXPugNJZ7Stn9F67hh/qH+2Y2HXK6vpBadW6qw==
+  dependencies:
+    "@fullhuman/postcss-purgecss" "^3.1.3"
+    autoprefixer "^9"
+    bytes "^3.0.0"
+    chalk "^4.1.0"
+    chokidar "^3.5.1"
+    color "^3.1.3"
+    detective "^5.2.0"
+    didyoumean "^1.2.1"
+    dlv "^1.1.3"
+    fast-glob "^3.2.5"
+    fs-extra "^9.1.0"
+    html-tags "^3.1.0"
+    lodash "^4.17.21"
+    lodash.topath "^4.5.2"
+    modern-normalize "^1.0.0"
+    node-emoji "^1.8.1"
+    normalize-path "^3.0.0"
+    object-hash "^2.1.1"
+    parse-glob "^3.0.4"
+    postcss "^7"
+    postcss-functions "^3"
+    postcss-js "^2"
+    postcss-nested "^4"
+    postcss-selector-parser "^6.0.4"
+    postcss-value-parser "^4.1.0"
+    pretty-hrtime "^1.0.3"
+    quick-lru "^5.1.1"
+    reduce-css-calc "^2.1.8"
+    resolve "^1.20.0"
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
# Description

Remove FS as an export option as it wasn't really useful. For now, only Sanity will be supported (though, it will be easy to add support for any other vendor we want).

Going forward, when adding support for a vendor, **make sure they support the ability to manage the schema from the API**. Sanity is an exception to this rule only because we have previous experience with Sanity. We had to make a custom starter template in order to actually support Sanity, and I'd rather not have to do that for every provider.

## Change log
* Note in Readme about PostCSS vulnerability issue
* `yarn reset`
    * Command to delete `dist`, `out`, project `node_modules` and all package `node_modules` directories and reinstall all dependencies
    * Use this when:
        * _You've just started on a new branch and want to ensure everything is in a "fresh" state_
        * _You've added a dependency to any of the `package.json` files, are feeling particularly lazy and just want to have a "one and done" command to reset all dependencies_
        * _You've made **a lot** of changes to any of the `package.json` files_
    * A word of caution...
        * **_This will reinstall ALL package dependencies, even if nothing changed in the project/package `package.json`_**
        * This is a heavy-handed command; if you're only using this to install one or two dependencies at a time, and find yourself having to do so frequently within the same PR, you should probably just `cd` to the correct location and `rm -rf node_modules`, then re-run `yarn`
* "Remove" the FS export option
    * It simply isn't exposed on the front end anymore - the backend endpoints are still in place if we want to re-implement them later