### PR TITLE
Prevent duplicate webapp tab from opening

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,8 @@ This section contains information about specific cases where there is "a reason"
 1. **PostCSS** - `^7` - _this version has a moderate vulnerability and it's recommended we update to `>=8.2.10`_
    - We can't easily fix this as it's a problem with `create-react-app`, which does not work with version 8
    - See: https://github.com/postcss/postcss/wiki/PostCSS-8-for-end-users
+2. **`ws` (indirect-dependency)** - _Any version 7 `ws` lower than `7.4.6` is vulnerable to attack via a specially-crafted `Sec-Websocket-Protocol` header_
+   - No need for us to fix this, as the server for this application is intended only to be hosted locally, while a user is configuring their site content
+     - The only threat would be from the user themselves (meaning they would have to manually host the app, craft the header, then attack themselves for no reason whatsoever)
+     - DO NOT TRIVIALIZE THIS - if, for whatever reason, you do intend to host this app, know that the app will have this vulnerability and you will need to find a fix (yes, we are open to PRs!)
+   - See: https://github.com/advisories/GHSA-6fc8-4gx4-v693

--- a/packages/cli/src/CLIApp.tsx
+++ b/packages/cli/src/CLIApp.tsx
@@ -43,9 +43,23 @@ export const CLIApp = () => {
       }
       // This option is only visible when LOCAL is false (e.g., when running the built app, instead of running the CLI and webapp separately)
       case OPTION_VALUE.OPEN_WEBAPP: {
-        open(`http://localhost:3000`).then(() => clearSelectedOptionHandler())
+        open(`http://localhost:3000`)
       }
       default: {
+        /**
+         * N.B.
+         *
+         * De-selecting menu options that rendered no additional content to the CLIApp
+         *
+         * For example - refer to OPEN_WEBAPP. When this option is selected, we simply open a tab to the locally-hosted webapp. No changes are made to the
+         * rendered CLIApp component - it simply opens a tab. After the tab is opened, we utilize switch fall-through logic so that, for OPEN_WEBAPP (or
+         * any other option we add later that doesn't modify the rendered content of CLIApp), subsequent menu selections are always made from a fresh state,
+         * where the previous selection has been cleared from the state.
+         *
+         * Tl;dr - if adding a menu option that doesn't modify the rendered content of CLIApp, DON'T return in the switch case - simply run the side effect
+         * logic and let it fall through to the default case.
+         */
+        if (selectedOption !== null) clearSelectedOptionHandler()
         return <></>
       }
     }


### PR DESCRIPTION
# Description

Prevent duplicate tab from opening when clicking "open webapp" menu option.

## Fix details

This happened because the callback to `open` was triggering an additional render cycle, during which, the selected menu option was still `OPEN_WEBAPP`. This caused the `open` logic to be run exactly twice:
* **First time**: The "expected" open call
* **Second time**: The "extra" open call, triggered by the callback to `open`
    * This would not trigger a third rendering because, by running the logic of the callback, the menu option was de-selected by `clearSelectedOptionHandler`
        * Though this technically does trigger another render cycle, it won't lead to an additional tab being opened because, in the third run, the selected menu option is `null`

## Change log
* Fix to prevent opening duplicate webapp tab
* Information regarding Dependabot alert for `ws` package (an alert we can safely disregard as the app is intended to be self-hosted and only subject to potential attack from the user themselves :man_shrugging: pretty unlikely, imo)