### PR TITLE
Enforce required fields for blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "clean": "rm -rf out/ dist/ node_modules packages/cli/node_modules packages/client/node_modules",
     "reset": "yarn clean && yarn && yarn lerna bootstrap && cd packages/cli && yarn && cd ../client && yarn",
+    "clear-db": "rm -rf /tmp/minecraft-asset-reader",
     "lint:commit": "prettier-eslint \"{src/**/*,test/**/*,packages/**/*}.{ts,tsx}\" --eslint-config-path=.eslintrc.yml --write",
     "prepare": "husky install",
     "reset-db": "rm -rf /tmp/minecraft-asset-reader",

--- a/packages/cli/src/db/mutations/createTables.ts
+++ b/packages/cli/src/db/mutations/createTables.ts
@@ -16,13 +16,13 @@ export const CREATE_IMPORTED_GAME_VERSION_TABLE = `CREATE TABLE IF NOT EXISTS im
 )`
 
 export const CREATE_HARVEST_TOOL_TABLE = `CREATE TABLE IF NOT EXISTS harvest_tool (
-    id  INTEGER    PRIMARY KEY AUTOINCREMENT,
-    key TEXT       NOT NULL UNIQUE
+    id          INTEGER    PRIMARY KEY AUTOINCREMENT,
+    key         TEXT       NOT NULL UNIQUE
 )`
 
 export const CREATE_HARVEST_TOOL_QUALITY_TABLE = `CREATE TABLE IF NOT EXISTS harvest_tool_quality (
-    id  INTEGER    PRIMARY KEY AUTOINCREMENT,
-    key TEXT       NOT NULL UNIQUE
+    id          INTEGER    PRIMARY KEY AUTOINCREMENT,
+    key         TEXT       NOT NULL UNIQUE
 )`
 
 export const CREATE_BLOCK_TABLE = `CREATE TABLE IF NOT EXISTS block (
@@ -39,7 +39,7 @@ export const CREATE_BLOCK_TABLE = `CREATE TABLE IF NOT EXISTS block (
     min_spawn                       INTEGER DEFAULT 0,
     max_spawn                       INTEGER DEFAULT 0,
     namespace_id                    INTEGER,
-    FOREIGN KEY (namespace_id) REFERENCES namespace (ingredient_for_blocks) ON DELETE CASCADE ON UPDATE CASCADE
+    FOREIGN KEY (namespace_id) REFERENCES namespace (namespace_id) ON DELETE CASCADE ON UPDATE CASCADE
 )`
 
 export const CREATE_HARVEST_TOOL_TO_BLOCK_TABLE = `CREATE TABLE IF NOT EXISTS harvest_tool_to_block (

--- a/packages/client/src/components/block-modal/BlockModal.tsx
+++ b/packages/client/src/components/block-modal/BlockModal.tsx
@@ -345,7 +345,9 @@ export const BlockModal = (props: {
     modalState.title.length === 0 ||
     modalState.top === NONE ||
     modalState.right === NONE ||
-    modalState.left === NONE
+    modalState.left === NONE ||
+    modalState.harvestTool === `` ||
+    modalState.harvestToolQualities.length === 0
   return (
     <>
       <div className="modal-overlay" />


### PR DESCRIPTION
# Description

Make tool and qualities required when configuring them, and upload them to Sanity on export.

## Change log
* `yarn clear-db` command - simply deletes all DB data (useful anytime you make a change to the DB schema)
* Pass harvest tool and qualities to Sanity on upload
* Make Block modal save button disabled when harvest tool and qualities are unset