### PR TITLE
Refactor project setup for NPM builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ build
 # TODO:
 report.**.json
 yarn-error.log
+
+# Build-related files and folders
+bin/minecraft-asset-reader.json
+bin/minecraft-asset-reader.js.LICENSE.txt
+bin/xdg-open
+**/vendor/yarn

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+
+/packages
+/bin/entry.js
+/test
+/.husky
+/.vscode
+/.babelrc
+/.editorconfig
+/.eslintignore
+/.eslintrc*
+/yarn.lock
+tsconfig.tsbuildinfo

--- a/bin/entry.js
+++ b/bin/entry.js
@@ -1,0 +1,1 @@
+require(`../out/cli/src/main`).cli(process.argv)

--- a/bin/minecraft-asset-reader
+++ b/bin/minecraft-asset-reader
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+// require = require('esm')(module /*, options*/);
+// require('../out/cli/src/main').cli(process.argv);
+
+/* eslint-disable no-var, no-console, no-process-exit, prefer-template, import/no-unassigned-import */
+/**
+ * ┌────────────────┐
+ * │                │
+ * │ WEBPACK ENTRY  │
+ * │ NO ES6 IN HERE │
+ * │                │
+ * └────────────────┘
+ */
+
+// var err = '\u001b[31m\u001b[1mERROR:\u001b[22m\u001b[39m '
+// var nodeVersionParts = process.version
+//   .replace(/^v/i, '')
+//   .split('.')
+//   .map(Number)
+
+// var majorVersion = nodeVersionParts[0]
+// var minorVersion = nodeVersionParts[1]
+// if (majorVersion < 8 || (majorVersion === 8 && minorVersion < 6)) {
+//   console.error(err + 'Node.js version 8.6 or higher required. You are running ' + process.version)
+//   console.error('')
+//   process.exit(1)
+// }
+
+try {
+  // Default, unpackaged version for development
+  require('./entry')
+  return
+} catch (error) {
+  // Probably in "production", flow through to pre-packaged
+}
+
+// Pre-packaged
+require('./sanity-cli')

--- a/bin/minecraft-asset-reader.js
+++ b/bin/minecraft-asset-reader.js
@@ -1,0 +1,2618 @@
+#!/usr/bin/env node
+/*! For license information please see minecraft-asset-reader.js.LICENSE.txt */
+;(() => {
+  var e = {
+      9669: (e, t, r) => {
+        e.exports = r(1609)
+      },
+      7970: (e, t, r) => {
+        "use strict"
+        var n = r(4867),
+          o = r(6026),
+          s = r(4097),
+          i = r(5327),
+          a = r(8605),
+          u = r(7211),
+          c = r(938).http,
+          f = r(938).https,
+          p = r(8835),
+          l = r(8761),
+          d = r(696),
+          h = r(5061),
+          m = r(481),
+          g = /https:?/
+        function y(e, t, r) {
+          if (
+            ((e.hostname = t.host),
+            (e.host = t.host),
+            (e.port = t.port),
+            (e.path = r),
+            t.auth)
+          ) {
+            var n = Buffer.from(
+              t.auth.username + `:` + t.auth.password,
+              `utf8`
+            ).toString(`base64`)
+            e.headers[`Proxy-Authorization`] = `Basic ` + n
+          }
+          e.beforeRedirect = function (e) {
+            ;(e.headers.host = e.host), y(e, t, e.href)
+          }
+        }
+        e.exports = function (e) {
+          return new Promise(function (t, r) {
+            var v = function (e) {
+                t(e)
+              },
+              C = function (e) {
+                r(e)
+              },
+              b = e.data,
+              _ = e.headers
+            if (
+              (_[`User-Agent`] ||
+                _[`user-agent`] ||
+                (_[`User-Agent`] = `axios/` + d.version),
+              b && !n.isStream(b))
+            ) {
+              if (Buffer.isBuffer(b));
+              else if (n.isArrayBuffer(b)) b = Buffer.from(new Uint8Array(b))
+              else {
+                if (!n.isString(b))
+                  return C(
+                    h(
+                      `Data after transformation must be a string, an ArrayBuffer, a Buffer, or a Stream`,
+                      e
+                    )
+                  )
+                b = Buffer.from(b, `utf-8`)
+              }
+              _[`Content-Length`] = b.length
+            }
+            var x = void 0
+            e.auth &&
+              (x = (e.auth.username || ``) + `:` + (e.auth.password || ``))
+            var w = s(e.baseURL, e.url),
+              R = p.parse(w),
+              E = R.protocol || `http:`
+            if (!x && R.auth) {
+              var O = R.auth.split(`:`)
+              x = (O[0] || ``) + `:` + (O[1] || ``)
+            }
+            x && delete _.Authorization
+            var j = g.test(E),
+              F = j ? e.httpsAgent : e.httpAgent,
+              k = {
+                path: i(R.path, e.params, e.paramsSerializer).replace(
+                  /^\?/,
+                  ``
+                ),
+                method: e.method.toUpperCase(),
+                headers: _,
+                agent: F,
+                agents: { http: e.httpAgent, https: e.httpsAgent },
+                auth: x,
+              }
+            e.socketPath
+              ? (k.socketPath = e.socketPath)
+              : ((k.hostname = R.hostname), (k.port = R.port))
+            var A,
+              S = e.proxy
+            if (!S && !1 !== S) {
+              var T = E.slice(0, -1) + `_proxy`,
+                B = process.env[T] || process.env[T.toUpperCase()]
+              if (B) {
+                var L = p.parse(B),
+                  q = process.env.no_proxy || process.env.NO_PROXY,
+                  N = !0
+                if (
+                  (q &&
+                    (N = !q
+                      .split(`,`)
+                      .map(function (e) {
+                        return e.trim()
+                      })
+                      .some(function (e) {
+                        return (
+                          !!e &&
+                          (`*` === e ||
+                            (`.` === e[0] &&
+                              R.hostname.substr(
+                                R.hostname.length - e.length
+                              ) === e) ||
+                            R.hostname === e)
+                        )
+                      })),
+                  N &&
+                    ((S = {
+                      host: L.hostname,
+                      port: L.port,
+                      protocol: L.protocol,
+                    }),
+                    L.auth))
+                ) {
+                  var P = L.auth.split(`:`)
+                  S.auth = { username: P[0], password: P[1] }
+                }
+              }
+            }
+            S &&
+              ((k.headers.host = R.hostname + (R.port ? `:` + R.port : ``)),
+              y(
+                k,
+                S,
+                E + `//` + R.hostname + (R.port ? `:` + R.port : ``) + k.path
+              ))
+            var U = j && (!S || g.test(S.protocol))
+            e.transport
+              ? (A = e.transport)
+              : 0 === e.maxRedirects
+              ? (A = U ? u : a)
+              : (e.maxRedirects && (k.maxRedirects = e.maxRedirects),
+                (A = U ? f : c)),
+              e.maxBodyLength > -1 && (k.maxBodyLength = e.maxBodyLength)
+            var I = A.request(k, function (t) {
+              if (!I.aborted) {
+                var r = t,
+                  s = t.req || I
+                if (
+                  204 !== t.statusCode &&
+                  `HEAD` !== s.method &&
+                  !1 !== e.decompress
+                )
+                  switch (t.headers[`content-encoding`]) {
+                    case `gzip`:
+                    case `compress`:
+                    case `deflate`:
+                      ;(r = r.pipe(l.createUnzip())),
+                        delete t.headers[`content-encoding`]
+                  }
+                var i = {
+                  status: t.statusCode,
+                  statusText: t.statusMessage,
+                  headers: t.headers,
+                  config: e,
+                  request: s,
+                }
+                if (`stream` === e.responseType) (i.data = r), o(v, C, i)
+                else {
+                  var a = []
+                  r.on(`data`, function (t) {
+                    a.push(t),
+                      e.maxContentLength > -1 &&
+                        Buffer.concat(a).length > e.maxContentLength &&
+                        (r.destroy(),
+                        C(
+                          h(
+                            `maxContentLength size of ` +
+                              e.maxContentLength +
+                              ` exceeded`,
+                            e,
+                            null,
+                            s
+                          )
+                        ))
+                  }),
+                    r.on(`error`, function (t) {
+                      I.aborted || C(m(t, e, null, s))
+                    }),
+                    r.on(`end`, function () {
+                      var t = Buffer.concat(a)
+                      `arraybuffer` !== e.responseType &&
+                        ((t = t.toString(e.responseEncoding)),
+                        (e.responseEncoding && `utf8` !== e.responseEncoding) ||
+                          (t = n.stripBOM(t))),
+                        (i.data = t),
+                        o(v, C, i)
+                    })
+                }
+              }
+            })
+            I.on(`error`, function (t) {
+              ;(I.aborted && `ERR_FR_TOO_MANY_REDIRECTS` !== t.code) ||
+                C(m(t, e, null, I))
+            }),
+              e.timeout &&
+                I.setTimeout(e.timeout, function () {
+                  I.abort(),
+                    C(
+                      h(
+                        `timeout of ` + e.timeout + `ms exceeded`,
+                        e,
+                        `ECONNABORTED`,
+                        I
+                      )
+                    )
+                }),
+              e.cancelToken &&
+                e.cancelToken.promise.then(function (e) {
+                  I.aborted || (I.abort(), C(e))
+                }),
+              n.isStream(b)
+                ? b
+                    .on(`error`, function (t) {
+                      C(m(t, e, null, I))
+                    })
+                    .pipe(I)
+                : I.end(b)
+          })
+        }
+      },
+      5448: (e, t, r) => {
+        "use strict"
+        var n = r(4867),
+          o = r(6026),
+          s = r(4372),
+          i = r(5327),
+          a = r(4097),
+          u = r(4109),
+          c = r(7985),
+          f = r(5061)
+        e.exports = function (e) {
+          return new Promise(function (t, r) {
+            var p = e.data,
+              l = e.headers
+            n.isFormData(p) && delete l[`Content-Type`]
+            var d = new XMLHttpRequest()
+            if (e.auth) {
+              var h = e.auth.username || ``,
+                m = e.auth.password
+                  ? unescape(encodeURIComponent(e.auth.password))
+                  : ``
+              l.Authorization = `Basic ` + btoa(h + `:` + m)
+            }
+            var g = a(e.baseURL, e.url)
+            if (
+              (d.open(
+                e.method.toUpperCase(),
+                i(g, e.params, e.paramsSerializer),
+                !0
+              ),
+              (d.timeout = e.timeout),
+              (d.onreadystatechange = function () {
+                if (
+                  d &&
+                  4 === d.readyState &&
+                  (0 !== d.status ||
+                    (d.responseURL && 0 === d.responseURL.indexOf(`file:`)))
+                ) {
+                  var n =
+                      `getAllResponseHeaders` in d
+                        ? u(d.getAllResponseHeaders())
+                        : null,
+                    s = {
+                      data:
+                        e.responseType && `text` !== e.responseType
+                          ? d.response
+                          : d.responseText,
+                      status: d.status,
+                      statusText: d.statusText,
+                      headers: n,
+                      config: e,
+                      request: d,
+                    }
+                  o(t, r, s), (d = null)
+                }
+              }),
+              (d.onabort = function () {
+                d && (r(f(`Request aborted`, e, `ECONNABORTED`, d)), (d = null))
+              }),
+              (d.onerror = function () {
+                r(f(`Network Error`, e, null, d)), (d = null)
+              }),
+              (d.ontimeout = function () {
+                var t = `timeout of ` + e.timeout + `ms exceeded`
+                e.timeoutErrorMessage && (t = e.timeoutErrorMessage),
+                  r(f(t, e, `ECONNABORTED`, d)),
+                  (d = null)
+              }),
+              n.isStandardBrowserEnv())
+            ) {
+              var y =
+                (e.withCredentials || c(g)) && e.xsrfCookieName
+                  ? s.read(e.xsrfCookieName)
+                  : void 0
+              y && (l[e.xsrfHeaderName] = y)
+            }
+            if (
+              (`setRequestHeader` in d &&
+                n.forEach(l, function (e, t) {
+                  void 0 === p && `content-type` === t.toLowerCase()
+                    ? delete l[t]
+                    : d.setRequestHeader(t, e)
+                }),
+              n.isUndefined(e.withCredentials) ||
+                (d.withCredentials = !!e.withCredentials),
+              e.responseType)
+            )
+              try {
+                d.responseType = e.responseType
+              } catch (t) {
+                if (`json` !== e.responseType) throw t
+              }
+            `function` == typeof e.onDownloadProgress &&
+              d.addEventListener(`progress`, e.onDownloadProgress),
+              `function` == typeof e.onUploadProgress &&
+                d.upload &&
+                d.upload.addEventListener(`progress`, e.onUploadProgress),
+              e.cancelToken &&
+                e.cancelToken.promise.then(function (e) {
+                  d && (d.abort(), r(e), (d = null))
+                }),
+              p || (p = null),
+              d.send(p)
+          })
+        }
+      },
+      1609: (e, t, r) => {
+        "use strict"
+        var n = r(4867),
+          o = r(1849),
+          s = r(321),
+          i = r(7185)
+        function a(e) {
+          var t = new s(e),
+            r = o(s.prototype.request, t)
+          return n.extend(r, s.prototype, t), n.extend(r, t), r
+        }
+        var u = a(r(5655))
+        ;(u.Axios = s),
+          (u.create = function (e) {
+            return a(i(u.defaults, e))
+          }),
+          (u.Cancel = r(5263)),
+          (u.CancelToken = r(4972)),
+          (u.isCancel = r(6502)),
+          (u.all = function (e) {
+            return Promise.all(e)
+          }),
+          (u.spread = r(8713)),
+          (u.isAxiosError = r(6268)),
+          (e.exports = u),
+          (e.exports.default = u)
+      },
+      5263: (e) => {
+        "use strict"
+        function t(e) {
+          this.message = e
+        }
+        ;(t.prototype.toString = function () {
+          return `Cancel` + (this.message ? `: ` + this.message : ``)
+        }),
+          (t.prototype.__CANCEL__ = !0),
+          (e.exports = t)
+      },
+      4972: (e, t, r) => {
+        "use strict"
+        var n = r(5263)
+        function o(e) {
+          if (`function` != typeof e)
+            throw new TypeError(`executor must be a function.`)
+          var t
+          this.promise = new Promise(function (e) {
+            t = e
+          })
+          var r = this
+          e(function (e) {
+            r.reason || ((r.reason = new n(e)), t(r.reason))
+          })
+        }
+        ;(o.prototype.throwIfRequested = function () {
+          if (this.reason) throw this.reason
+        }),
+          (o.source = function () {
+            var e
+            return {
+              token: new o(function (t) {
+                e = t
+              }),
+              cancel: e,
+            }
+          }),
+          (e.exports = o)
+      },
+      6502: (e) => {
+        "use strict"
+        e.exports = function (e) {
+          return !(!e || !e.__CANCEL__)
+        }
+      },
+      321: (e, t, r) => {
+        "use strict"
+        var n = r(4867),
+          o = r(5327),
+          s = r(782),
+          i = r(3572),
+          a = r(7185)
+        function u(e) {
+          ;(this.defaults = e),
+            (this.interceptors = { request: new s(), response: new s() })
+        }
+        ;(u.prototype.request = function (e) {
+          `string` == typeof e
+            ? ((e = arguments[1] || {}).url = arguments[0])
+            : (e = e || {}),
+            (e = a(this.defaults, e)).method
+              ? (e.method = e.method.toLowerCase())
+              : this.defaults.method
+              ? (e.method = this.defaults.method.toLowerCase())
+              : (e.method = `get`)
+          var t = [i, void 0],
+            r = Promise.resolve(e)
+          for (
+            this.interceptors.request.forEach(function (e) {
+              t.unshift(e.fulfilled, e.rejected)
+            }),
+              this.interceptors.response.forEach(function (e) {
+                t.push(e.fulfilled, e.rejected)
+              });
+            t.length;
+
+          )
+            r = r.then(t.shift(), t.shift())
+          return r
+        }),
+          (u.prototype.getUri = function (e) {
+            return (
+              (e = a(this.defaults, e)),
+              o(e.url, e.params, e.paramsSerializer).replace(/^\?/, ``)
+            )
+          }),
+          n.forEach([`delete`, `get`, `head`, `options`], function (e) {
+            u.prototype[e] = function (t, r) {
+              return this.request(
+                a(r || {}, { method: e, url: t, data: (r || {}).data })
+              )
+            }
+          }),
+          n.forEach([`post`, `put`, `patch`], function (e) {
+            u.prototype[e] = function (t, r, n) {
+              return this.request(a(n || {}, { method: e, url: t, data: r }))
+            }
+          }),
+          (e.exports = u)
+      },
+      782: (e, t, r) => {
+        "use strict"
+        var n = r(4867)
+        function o() {
+          this.handlers = []
+        }
+        ;(o.prototype.use = function (e, t) {
+          return (
+            this.handlers.push({ fulfilled: e, rejected: t }),
+            this.handlers.length - 1
+          )
+        }),
+          (o.prototype.eject = function (e) {
+            this.handlers[e] && (this.handlers[e] = null)
+          }),
+          (o.prototype.forEach = function (e) {
+            n.forEach(this.handlers, function (t) {
+              null !== t && e(t)
+            })
+          }),
+          (e.exports = o)
+      },
+      4097: (e, t, r) => {
+        "use strict"
+        var n = r(1793),
+          o = r(7303)
+        e.exports = function (e, t) {
+          return e && !n(t) ? o(e, t) : t
+        }
+      },
+      5061: (e, t, r) => {
+        "use strict"
+        var n = r(481)
+        e.exports = function (e, t, r, o, s) {
+          var i = new Error(e)
+          return n(i, t, r, o, s)
+        }
+      },
+      3572: (e, t, r) => {
+        "use strict"
+        var n = r(4867),
+          o = r(8527),
+          s = r(6502),
+          i = r(5655)
+        function a(e) {
+          e.cancelToken && e.cancelToken.throwIfRequested()
+        }
+        e.exports = function (e) {
+          return (
+            a(e),
+            (e.headers = e.headers || {}),
+            (e.data = o(e.data, e.headers, e.transformRequest)),
+            (e.headers = n.merge(
+              e.headers.common || {},
+              e.headers[e.method] || {},
+              e.headers
+            )),
+            n.forEach(
+              [`delete`, `get`, `head`, `post`, `put`, `patch`, `common`],
+              function (t) {
+                delete e.headers[t]
+              }
+            ),
+            (e.adapter || i.adapter)(e).then(
+              function (t) {
+                return (
+                  a(e), (t.data = o(t.data, t.headers, e.transformResponse)), t
+                )
+              },
+              function (t) {
+                return (
+                  s(t) ||
+                    (a(e),
+                    t &&
+                      t.response &&
+                      (t.response.data = o(
+                        t.response.data,
+                        t.response.headers,
+                        e.transformResponse
+                      ))),
+                  Promise.reject(t)
+                )
+              }
+            )
+          )
+        }
+      },
+      481: (e) => {
+        "use strict"
+        e.exports = function (e, t, r, n, o) {
+          return (
+            (e.config = t),
+            r && (e.code = r),
+            (e.request = n),
+            (e.response = o),
+            (e.isAxiosError = !0),
+            (e.toJSON = function () {
+              return {
+                message: this.message,
+                name: this.name,
+                description: this.description,
+                number: this.number,
+                fileName: this.fileName,
+                lineNumber: this.lineNumber,
+                columnNumber: this.columnNumber,
+                stack: this.stack,
+                config: this.config,
+                code: this.code,
+              }
+            }),
+            e
+          )
+        }
+      },
+      7185: (e, t, r) => {
+        "use strict"
+        var n = r(4867)
+        e.exports = function (e, t) {
+          t = t || {}
+          var r = {},
+            o = [`url`, `method`, `data`],
+            s = [`headers`, `auth`, `proxy`, `params`],
+            i = [
+              `baseURL`,
+              `transformRequest`,
+              `transformResponse`,
+              `paramsSerializer`,
+              `timeout`,
+              `timeoutMessage`,
+              `withCredentials`,
+              `adapter`,
+              `responseType`,
+              `xsrfCookieName`,
+              `xsrfHeaderName`,
+              `onUploadProgress`,
+              `onDownloadProgress`,
+              `decompress`,
+              `maxContentLength`,
+              `maxBodyLength`,
+              `maxRedirects`,
+              `transport`,
+              `httpAgent`,
+              `httpsAgent`,
+              `cancelToken`,
+              `socketPath`,
+              `responseEncoding`,
+            ],
+            a = [`validateStatus`]
+          function u(e, t) {
+            return n.isPlainObject(e) && n.isPlainObject(t)
+              ? n.merge(e, t)
+              : n.isPlainObject(t)
+              ? n.merge({}, t)
+              : n.isArray(t)
+              ? t.slice()
+              : t
+          }
+          function c(o) {
+            n.isUndefined(t[o])
+              ? n.isUndefined(e[o]) || (r[o] = u(void 0, e[o]))
+              : (r[o] = u(e[o], t[o]))
+          }
+          n.forEach(o, function (e) {
+            n.isUndefined(t[e]) || (r[e] = u(void 0, t[e]))
+          }),
+            n.forEach(s, c),
+            n.forEach(i, function (o) {
+              n.isUndefined(t[o])
+                ? n.isUndefined(e[o]) || (r[o] = u(void 0, e[o]))
+                : (r[o] = u(void 0, t[o]))
+            }),
+            n.forEach(a, function (n) {
+              n in t
+                ? (r[n] = u(e[n], t[n]))
+                : n in e && (r[n] = u(void 0, e[n]))
+            })
+          var f = o.concat(s).concat(i).concat(a),
+            p = Object.keys(e)
+              .concat(Object.keys(t))
+              .filter(function (e) {
+                return -1 === f.indexOf(e)
+              })
+          return n.forEach(p, c), r
+        }
+      },
+      6026: (e, t, r) => {
+        "use strict"
+        var n = r(5061)
+        e.exports = function (e, t, r) {
+          var o = r.config.validateStatus
+          r.status && o && !o(r.status)
+            ? t(
+                n(
+                  `Request failed with status code ` + r.status,
+                  r.config,
+                  null,
+                  r.request,
+                  r
+                )
+              )
+            : e(r)
+        }
+      },
+      8527: (e, t, r) => {
+        "use strict"
+        var n = r(4867)
+        e.exports = function (e, t, r) {
+          return (
+            n.forEach(r, function (r) {
+              e = r(e, t)
+            }),
+            e
+          )
+        }
+      },
+      5655: (e, t, r) => {
+        "use strict"
+        var n = r(4867),
+          o = r(6016),
+          s = { "Content-Type": `application/x-www-form-urlencoded` }
+        function i(e, t) {
+          !n.isUndefined(e) &&
+            n.isUndefined(e[`Content-Type`]) &&
+            (e[`Content-Type`] = t)
+        }
+        var a,
+          u = {
+            adapter:
+              (`undefined` != typeof XMLHttpRequest
+                ? (a = r(5448))
+                : `undefined` != typeof process &&
+                  `[object process]` ===
+                    Object.prototype.toString.call(process) &&
+                  (a = r(7970)),
+              a),
+            transformRequest: [
+              function (e, t) {
+                return (
+                  o(t, `Accept`),
+                  o(t, `Content-Type`),
+                  n.isFormData(e) ||
+                  n.isArrayBuffer(e) ||
+                  n.isBuffer(e) ||
+                  n.isStream(e) ||
+                  n.isFile(e) ||
+                  n.isBlob(e)
+                    ? e
+                    : n.isArrayBufferView(e)
+                    ? e.buffer
+                    : n.isURLSearchParams(e)
+                    ? (i(t, `application/x-www-form-urlencoded;charset=utf-8`),
+                      e.toString())
+                    : n.isObject(e)
+                    ? (i(t, `application/json;charset=utf-8`),
+                      JSON.stringify(e))
+                    : e
+                )
+              },
+            ],
+            transformResponse: [
+              function (e) {
+                if (`string` == typeof e)
+                  try {
+                    e = JSON.parse(e)
+                  } catch (e) {}
+                return e
+              },
+            ],
+            timeout: 0,
+            xsrfCookieName: `XSRF-TOKEN`,
+            xsrfHeaderName: `X-XSRF-TOKEN`,
+            maxContentLength: -1,
+            maxBodyLength: -1,
+            validateStatus: function (e) {
+              return e >= 200 && e < 300
+            },
+            headers: {
+              common: { Accept: `application/json, text/plain, */*` },
+            },
+          }
+        n.forEach([`delete`, `get`, `head`], function (e) {
+          u.headers[e] = {}
+        }),
+          n.forEach([`post`, `put`, `patch`], function (e) {
+            u.headers[e] = n.merge(s)
+          }),
+          (e.exports = u)
+      },
+      1849: (e) => {
+        "use strict"
+        e.exports = function (e, t) {
+          return function () {
+            for (var r = new Array(arguments.length), n = 0; n < r.length; n++)
+              r[n] = arguments[n]
+            return e.apply(t, r)
+          }
+        }
+      },
+      5327: (e, t, r) => {
+        "use strict"
+        var n = r(4867)
+        function o(e) {
+          return encodeURIComponent(e)
+            .replace(/%3A/gi, `:`)
+            .replace(/%24/g, `$`)
+            .replace(/%2C/gi, `,`)
+            .replace(/%20/g, `+`)
+            .replace(/%5B/gi, `[`)
+            .replace(/%5D/gi, `]`)
+        }
+        e.exports = function (e, t, r) {
+          if (!t) return e
+          var s
+          if (r) s = r(t)
+          else if (n.isURLSearchParams(t)) s = t.toString()
+          else {
+            var i = []
+            n.forEach(t, function (e, t) {
+              null != e &&
+                (n.isArray(e) ? (t += `[]`) : (e = [e]),
+                n.forEach(e, function (e) {
+                  n.isDate(e)
+                    ? (e = e.toISOString())
+                    : n.isObject(e) && (e = JSON.stringify(e)),
+                    i.push(o(t) + `=` + o(e))
+                }))
+            }),
+              (s = i.join(`&`))
+          }
+          if (s) {
+            var a = e.indexOf(`#`)
+            ;-1 !== a && (e = e.slice(0, a)),
+              (e += (-1 === e.indexOf(`?`) ? `?` : `&`) + s)
+          }
+          return e
+        }
+      },
+      7303: (e) => {
+        "use strict"
+        e.exports = function (e, t) {
+          return t ? e.replace(/\/+$/, ``) + `/` + t.replace(/^\/+/, ``) : e
+        }
+      },
+      4372: (e, t, r) => {
+        "use strict"
+        var n = r(4867)
+        e.exports = n.isStandardBrowserEnv()
+          ? {
+              write: function (e, t, r, o, s, i) {
+                var a = []
+                a.push(e + `=` + encodeURIComponent(t)),
+                  n.isNumber(r) &&
+                    a.push(`expires=` + new Date(r).toGMTString()),
+                  n.isString(o) && a.push(`path=` + o),
+                  n.isString(s) && a.push(`domain=` + s),
+                  !0 === i && a.push(`secure`),
+                  (document.cookie = a.join(`; `))
+              },
+              read: function (e) {
+                var t = document.cookie.match(
+                  new RegExp(`(^|;\\s*)(` + e + `)=([^;]*)`)
+                )
+                return t ? decodeURIComponent(t[3]) : null
+              },
+              remove: function (e) {
+                this.write(e, ``, Date.now() - 864e5)
+              },
+            }
+          : {
+              write: function () {},
+              read: function () {
+                return null
+              },
+              remove: function () {},
+            }
+      },
+      1793: (e) => {
+        "use strict"
+        e.exports = function (e) {
+          return /^([a-z][a-z\d\+\-\.]*:)?\/\//i.test(e)
+        }
+      },
+      6268: (e) => {
+        "use strict"
+        e.exports = function (e) {
+          return `object` == typeof e && !0 === e.isAxiosError
+        }
+      },
+      7985: (e, t, r) => {
+        "use strict"
+        var n = r(4867)
+        e.exports = n.isStandardBrowserEnv()
+          ? (function () {
+              var e,
+                t = /(msie|trident)/i.test(navigator.userAgent),
+                r = document.createElement(`a`)
+              function o(e) {
+                var n = e
+                return (
+                  t && (r.setAttribute(`href`, n), (n = r.href)),
+                  r.setAttribute(`href`, n),
+                  {
+                    href: r.href,
+                    protocol: r.protocol ? r.protocol.replace(/:$/, ``) : ``,
+                    host: r.host,
+                    search: r.search ? r.search.replace(/^\?/, ``) : ``,
+                    hash: r.hash ? r.hash.replace(/^#/, ``) : ``,
+                    hostname: r.hostname,
+                    port: r.port,
+                    pathname:
+                      `/` === r.pathname.charAt(0)
+                        ? r.pathname
+                        : `/` + r.pathname,
+                  }
+                )
+              }
+              return (
+                (e = o(window.location.href)),
+                function (t) {
+                  var r = n.isString(t) ? o(t) : t
+                  return r.protocol === e.protocol && r.host === e.host
+                }
+              )
+            })()
+          : function () {
+              return !0
+            }
+      },
+      6016: (e, t, r) => {
+        "use strict"
+        var n = r(4867)
+        e.exports = function (e, t) {
+          n.forEach(e, function (r, n) {
+            n !== t &&
+              n.toUpperCase() === t.toUpperCase() &&
+              ((e[t] = r), delete e[n])
+          })
+        }
+      },
+      4109: (e, t, r) => {
+        "use strict"
+        var n = r(4867),
+          o = [
+            `age`,
+            `authorization`,
+            `content-length`,
+            `content-type`,
+            `etag`,
+            `expires`,
+            `from`,
+            `host`,
+            `if-modified-since`,
+            `if-unmodified-since`,
+            `last-modified`,
+            `location`,
+            `max-forwards`,
+            `proxy-authorization`,
+            `referer`,
+            `retry-after`,
+            `user-agent`,
+          ]
+        e.exports = function (e) {
+          var t,
+            r,
+            s,
+            i = {}
+          return e
+            ? (n.forEach(e.split(`\n`), function (e) {
+                if (
+                  ((s = e.indexOf(`:`)),
+                  (t = n.trim(e.substr(0, s)).toLowerCase()),
+                  (r = n.trim(e.substr(s + 1))),
+                  t)
+                ) {
+                  if (i[t] && o.indexOf(t) >= 0) return
+                  i[t] =
+                    `set-cookie` === t
+                      ? (i[t] ? i[t] : []).concat([r])
+                      : i[t]
+                      ? i[t] + `, ` + r
+                      : r
+                }
+              }),
+              i)
+            : i
+        }
+      },
+      8713: (e) => {
+        "use strict"
+        e.exports = function (e) {
+          return function (t) {
+            return e.apply(null, t)
+          }
+        }
+      },
+      4867: (e, t, r) => {
+        "use strict"
+        var n = r(1849),
+          o = Object.prototype.toString
+        function s(e) {
+          return `[object Array]` === o.call(e)
+        }
+        function i(e) {
+          return void 0 === e
+        }
+        function a(e) {
+          return null !== e && `object` == typeof e
+        }
+        function u(e) {
+          if (`[object Object]` !== o.call(e)) return !1
+          var t = Object.getPrototypeOf(e)
+          return null === t || t === Object.prototype
+        }
+        function c(e) {
+          return `[object Function]` === o.call(e)
+        }
+        function f(e, t) {
+          if (null != e)
+            if ((`object` != typeof e && (e = [e]), s(e)))
+              for (var r = 0, n = e.length; r < n; r++) t.call(null, e[r], r, e)
+            else
+              for (var o in e)
+                Object.prototype.hasOwnProperty.call(e, o) &&
+                  t.call(null, e[o], o, e)
+        }
+        e.exports = {
+          isArray: s,
+          isArrayBuffer: function (e) {
+            return `[object ArrayBuffer]` === o.call(e)
+          },
+          isBuffer: function (e) {
+            return (
+              null !== e &&
+              !i(e) &&
+              null !== e.constructor &&
+              !i(e.constructor) &&
+              `function` == typeof e.constructor.isBuffer &&
+              e.constructor.isBuffer(e)
+            )
+          },
+          isFormData: function (e) {
+            return `undefined` != typeof FormData && e instanceof FormData
+          },
+          isArrayBufferView: function (e) {
+            return `undefined` != typeof ArrayBuffer && ArrayBuffer.isView
+              ? ArrayBuffer.isView(e)
+              : e && e.buffer && e.buffer instanceof ArrayBuffer
+          },
+          isString: function (e) {
+            return `string` == typeof e
+          },
+          isNumber: function (e) {
+            return `number` == typeof e
+          },
+          isObject: a,
+          isPlainObject: u,
+          isUndefined: i,
+          isDate: function (e) {
+            return `[object Date]` === o.call(e)
+          },
+          isFile: function (e) {
+            return `[object File]` === o.call(e)
+          },
+          isBlob: function (e) {
+            return `[object Blob]` === o.call(e)
+          },
+          isFunction: c,
+          isStream: function (e) {
+            return a(e) && c(e.pipe)
+          },
+          isURLSearchParams: function (e) {
+            return (
+              `undefined` != typeof URLSearchParams &&
+              e instanceof URLSearchParams
+            )
+          },
+          isStandardBrowserEnv: function () {
+            return (
+              (`undefined` == typeof navigator ||
+                (`ReactNative` !== navigator.product &&
+                  `NativeScript` !== navigator.product &&
+                  `NS` !== navigator.product)) &&
+              `undefined` != typeof window &&
+              `undefined` != typeof document
+            )
+          },
+          forEach: f,
+          merge: function e() {
+            var t = {}
+            function r(r, n) {
+              u(t[n]) && u(r)
+                ? (t[n] = e(t[n], r))
+                : u(r)
+                ? (t[n] = e({}, r))
+                : s(r)
+                ? (t[n] = r.slice())
+                : (t[n] = r)
+            }
+            for (var n = 0, o = arguments.length; n < o; n++) f(arguments[n], r)
+            return t
+          },
+          extend: function (e, t, r) {
+            return (
+              f(t, function (t, o) {
+                e[o] = r && `function` == typeof t ? n(t, r) : t
+              }),
+              e
+            )
+          },
+          trim: function (e) {
+            return e.replace(/^\s*/, ``).replace(/\s*$/, ``)
+          },
+          stripBOM: function (e) {
+            return 65279 === e.charCodeAt(0) && (e = e.slice(1)), e
+          },
+        }
+      },
+      696: (e) => {
+        "use strict"
+        e.exports = JSON.parse(
+          `{"name":"axios","version":"0.21.1","description":"Promise based HTTP client for the browser and node.js","main":"index.js","scripts":{"test":"grunt test && bundlesize","start":"node ./sandbox/server.js","build":"NODE_ENV=production grunt build","preversion":"npm test","version":"npm run build && grunt version && git add -A dist && git add CHANGELOG.md bower.json package.json","postversion":"git push && git push --tags","examples":"node ./examples/server.js","coveralls":"cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js","fix":"eslint --fix lib/**/*.js"},"repository":{"type":"git","url":"https://github.com/axios/axios.git"},"keywords":["xhr","http","ajax","promise","node"],"author":"Matt Zabriskie","license":"MIT","bugs":{"url":"https://github.com/axios/axios/issues"},"homepage":"https://github.com/axios/axios","devDependencies":{"bundlesize":"^0.17.0","coveralls":"^3.0.0","es6-promise":"^4.2.4","grunt":"^1.0.2","grunt-banner":"^0.6.0","grunt-cli":"^1.2.0","grunt-contrib-clean":"^1.1.0","grunt-contrib-watch":"^1.0.0","grunt-eslint":"^20.1.0","grunt-karma":"^2.0.0","grunt-mocha-test":"^0.13.3","grunt-ts":"^6.0.0-beta.19","grunt-webpack":"^1.0.18","istanbul-instrumenter-loader":"^1.0.0","jasmine-core":"^2.4.1","karma":"^1.3.0","karma-chrome-launcher":"^2.2.0","karma-coverage":"^1.1.1","karma-firefox-launcher":"^1.1.0","karma-jasmine":"^1.1.1","karma-jasmine-ajax":"^0.1.13","karma-opera-launcher":"^1.0.0","karma-safari-launcher":"^1.0.0","karma-sauce-launcher":"^1.2.0","karma-sinon":"^1.0.5","karma-sourcemap-loader":"^0.3.7","karma-webpack":"^1.7.0","load-grunt-tasks":"^3.5.2","minimist":"^1.2.0","mocha":"^5.2.0","sinon":"^4.5.0","typescript":"^2.8.1","url-search-params":"^0.10.0","webpack":"^1.13.1","webpack-dev-server":"^1.14.1"},"browser":{"./lib/adapters/http.js":"./lib/adapters/xhr.js"},"jsdelivr":"dist/axios.min.js","unpkg":"dist/axios.min.js","typings":"./index.d.ts","dependencies":{"follow-redirects":"^1.10.0"},"bundlesize":[{"path":"./dist/axios.min.js","threshold":"5kB"}]}`
+        )
+      },
+      9435: (e) => {
+        var t = 1e3,
+          r = 60 * t,
+          n = 60 * r,
+          o = 24 * n
+        function s(e, t, r, n) {
+          var o = t >= 1.5 * r
+          return Math.round(e / r) + ` ` + n + (o ? `s` : ``)
+        }
+        e.exports = function (e, i) {
+          i = i || {}
+          var a,
+            u,
+            c = typeof e
+          if (`string` === c && e.length > 0)
+            return (function (e) {
+              if (!((e = String(e)).length > 100)) {
+                var s = /^(-?(?:\d+)?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)?$/i.exec(
+                  e
+                )
+                if (s) {
+                  var i = parseFloat(s[1])
+                  switch ((s[2] || `ms`).toLowerCase()) {
+                    case `years`:
+                    case `year`:
+                    case `yrs`:
+                    case `yr`:
+                    case `y`:
+                      return 315576e5 * i
+                    case `weeks`:
+                    case `week`:
+                    case `w`:
+                      return 6048e5 * i
+                    case `days`:
+                    case `day`:
+                    case `d`:
+                      return i * o
+                    case `hours`:
+                    case `hour`:
+                    case `hrs`:
+                    case `hr`:
+                    case `h`:
+                      return i * n
+                    case `minutes`:
+                    case `minute`:
+                    case `mins`:
+                    case `min`:
+                    case `m`:
+                      return i * r
+                    case `seconds`:
+                    case `second`:
+                    case `secs`:
+                    case `sec`:
+                    case `s`:
+                      return i * t
+                    case `milliseconds`:
+                    case `millisecond`:
+                    case `msecs`:
+                    case `msec`:
+                    case `ms`:
+                      return i
+                    default:
+                      return
+                  }
+                }
+              }
+            })(e)
+          if (`number` === c && isFinite(e))
+            return i.long
+              ? ((a = e),
+                (u = Math.abs(a)) >= o
+                  ? s(a, u, o, `day`)
+                  : u >= n
+                  ? s(a, u, n, `hour`)
+                  : u >= r
+                  ? s(a, u, r, `minute`)
+                  : u >= t
+                  ? s(a, u, t, `second`)
+                  : a + ` ms`)
+              : (function (e) {
+                  var s = Math.abs(e)
+                  return s >= o
+                    ? Math.round(e / o) + `d`
+                    : s >= n
+                    ? Math.round(e / n) + `h`
+                    : s >= r
+                    ? Math.round(e / r) + `m`
+                    : s >= t
+                    ? Math.round(e / t) + `s`
+                    : e + `ms`
+                })(e)
+          throw new Error(
+            `val is not a non-empty string or a valid number. val=` +
+              JSON.stringify(e)
+          )
+        }
+      },
+      1227: (e, t, r) => {
+        ;(t.formatArgs = function (t) {
+          if (
+            ((t[0] =
+              (this.useColors ? `%c` : ``) +
+              this.namespace +
+              (this.useColors ? ` %c` : ` `) +
+              t[0] +
+              (this.useColors ? `%c ` : ` `) +
+              `+` +
+              e.exports.humanize(this.diff)),
+            !this.useColors)
+          )
+            return
+          const r = `color: ` + this.color
+          t.splice(1, 0, r, `color: inherit`)
+          let n = 0,
+            o = 0
+          t[0].replace(/%[a-zA-Z%]/g, (e) => {
+            `%%` !== e && (n++, `%c` === e && (o = n))
+          }),
+            t.splice(o, 0, r)
+        }),
+          (t.save = function (e) {
+            try {
+              e ? t.storage.setItem(`debug`, e) : t.storage.removeItem(`debug`)
+            } catch (e) {}
+          }),
+          (t.load = function () {
+            let e
+            try {
+              e = t.storage.getItem(`debug`)
+            } catch (e) {}
+            return (
+              !e &&
+                `undefined` != typeof process &&
+                `env` in process &&
+                (e = process.env.DEBUG),
+              e
+            )
+          }),
+          (t.useColors = function () {
+            return (
+              !(
+                `undefined` == typeof window ||
+                !window.process ||
+                (`renderer` !== window.process.type && !window.process.__nwjs)
+              ) ||
+              ((`undefined` == typeof navigator ||
+                !navigator.userAgent ||
+                !navigator.userAgent
+                  .toLowerCase()
+                  .match(/(edge|trident)\/(\d+)/)) &&
+                ((`undefined` != typeof document &&
+                  document.documentElement &&
+                  document.documentElement.style &&
+                  document.documentElement.style.WebkitAppearance) ||
+                  (`undefined` != typeof window &&
+                    window.console &&
+                    (window.console.firebug ||
+                      (window.console.exception && window.console.table))) ||
+                  (`undefined` != typeof navigator &&
+                    navigator.userAgent &&
+                    navigator.userAgent.toLowerCase().match(/firefox\/(\d+)/) &&
+                    parseInt(RegExp.$1, 10) >= 31) ||
+                  (`undefined` != typeof navigator &&
+                    navigator.userAgent &&
+                    navigator.userAgent
+                      .toLowerCase()
+                      .match(/applewebkit\/(\d+)/))))
+            )
+          }),
+          (t.storage = (function () {
+            try {
+              return localStorage
+            } catch (e) {}
+          })()),
+          (t.destroy = (() => {
+            let e = !1
+            return () => {
+              e ||
+                ((e = !0),
+                console.warn(
+                  `Instance method \`debug.destroy()\` is deprecated and no longer does anything. It will be removed in the next major version of \`debug\`.`
+                ))
+            }
+          })()),
+          (t.colors = [
+            `#0000CC`,
+            `#0000FF`,
+            `#0033CC`,
+            `#0033FF`,
+            `#0066CC`,
+            `#0066FF`,
+            `#0099CC`,
+            `#0099FF`,
+            `#00CC00`,
+            `#00CC33`,
+            `#00CC66`,
+            `#00CC99`,
+            `#00CCCC`,
+            `#00CCFF`,
+            `#3300CC`,
+            `#3300FF`,
+            `#3333CC`,
+            `#3333FF`,
+            `#3366CC`,
+            `#3366FF`,
+            `#3399CC`,
+            `#3399FF`,
+            `#33CC00`,
+            `#33CC33`,
+            `#33CC66`,
+            `#33CC99`,
+            `#33CCCC`,
+            `#33CCFF`,
+            `#6600CC`,
+            `#6600FF`,
+            `#6633CC`,
+            `#6633FF`,
+            `#66CC00`,
+            `#66CC33`,
+            `#9900CC`,
+            `#9900FF`,
+            `#9933CC`,
+            `#9933FF`,
+            `#99CC00`,
+            `#99CC33`,
+            `#CC0000`,
+            `#CC0033`,
+            `#CC0066`,
+            `#CC0099`,
+            `#CC00CC`,
+            `#CC00FF`,
+            `#CC3300`,
+            `#CC3333`,
+            `#CC3366`,
+            `#CC3399`,
+            `#CC33CC`,
+            `#CC33FF`,
+            `#CC6600`,
+            `#CC6633`,
+            `#CC9900`,
+            `#CC9933`,
+            `#CCCC00`,
+            `#CCCC33`,
+            `#FF0000`,
+            `#FF0033`,
+            `#FF0066`,
+            `#FF0099`,
+            `#FF00CC`,
+            `#FF00FF`,
+            `#FF3300`,
+            `#FF3333`,
+            `#FF3366`,
+            `#FF3399`,
+            `#FF33CC`,
+            `#FF33FF`,
+            `#FF6600`,
+            `#FF6633`,
+            `#FF9900`,
+            `#FF9933`,
+            `#FFCC00`,
+            `#FFCC33`,
+          ]),
+          (t.log = console.debug || console.log || (() => {})),
+          (e.exports = r(2447)(t))
+        const { formatters: n } = e.exports
+        n.j = function (e) {
+          try {
+            return JSON.stringify(e)
+          } catch (e) {
+            return `[UnexpectedJSONParseError]: ` + e.message
+          }
+        }
+      },
+      2447: (e, t, r) => {
+        e.exports = function (e) {
+          function t(e) {
+            let r,
+              o = null
+            function s(...e) {
+              if (!s.enabled) return
+              const n = s,
+                o = Number(new Date()),
+                i = o - (r || o)
+              ;(n.diff = i),
+                (n.prev = r),
+                (n.curr = o),
+                (r = o),
+                (e[0] = t.coerce(e[0])),
+                `string` != typeof e[0] && e.unshift(`%O`)
+              let a = 0
+              ;(e[0] = e[0].replace(/%([a-zA-Z%])/g, (r, o) => {
+                if (`%%` === r) return `%`
+                a++
+                const s = t.formatters[o]
+                if (`function` == typeof s) {
+                  const t = e[a]
+                  ;(r = s.call(n, t)), e.splice(a, 1), a--
+                }
+                return r
+              })),
+                t.formatArgs.call(n, e),
+                (n.log || t.log).apply(n, e)
+            }
+            return (
+              (s.namespace = e),
+              (s.useColors = t.useColors()),
+              (s.color = t.selectColor(e)),
+              (s.extend = n),
+              (s.destroy = t.destroy),
+              Object.defineProperty(s, `enabled`, {
+                enumerable: !0,
+                configurable: !1,
+                get: () => (null === o ? t.enabled(e) : o),
+                set: (e) => {
+                  o = e
+                },
+              }),
+              `function` == typeof t.init && t.init(s),
+              s
+            )
+          }
+          function n(e, r) {
+            const n = t(this.namespace + (void 0 === r ? `:` : r) + e)
+            return (n.log = this.log), n
+          }
+          function o(e) {
+            return e
+              .toString()
+              .substring(2, e.toString().length - 2)
+              .replace(/\.\*\?$/, `*`)
+          }
+          return (
+            (t.debug = t),
+            (t.default = t),
+            (t.coerce = function (e) {
+              return e instanceof Error ? e.stack || e.message : e
+            }),
+            (t.disable = function () {
+              const e = [
+                ...t.names.map(o),
+                ...t.skips.map(o).map((e) => `-` + e),
+              ].join(`,`)
+              return t.enable(``), e
+            }),
+            (t.enable = function (e) {
+              let r
+              t.save(e), (t.names = []), (t.skips = [])
+              const n = (`string` == typeof e ? e : ``).split(/[\s,]+/),
+                o = n.length
+              for (r = 0; r < o; r++)
+                n[r] &&
+                  (`-` === (e = n[r].replace(/\*/g, `.*?`))[0]
+                    ? t.skips.push(new RegExp(`^` + e.substr(1) + `$`))
+                    : t.names.push(new RegExp(`^` + e + `$`)))
+            }),
+            (t.enabled = function (e) {
+              if (`*` === e[e.length - 1]) return !0
+              let r, n
+              for (r = 0, n = t.skips.length; r < n; r++)
+                if (t.skips[r].test(e)) return !1
+              for (r = 0, n = t.names.length; r < n; r++)
+                if (t.names[r].test(e)) return !0
+              return !1
+            }),
+            (t.humanize = r(9435)),
+            (t.destroy = function () {
+              console.warn(
+                `Instance method \`debug.destroy()\` is deprecated and no longer does anything. It will be removed in the next major version of \`debug\`.`
+              )
+            }),
+            Object.keys(e).forEach((r) => {
+              t[r] = e[r]
+            }),
+            (t.names = []),
+            (t.skips = []),
+            (t.formatters = {}),
+            (t.selectColor = function (e) {
+              let r = 0
+              for (let t = 0; t < e.length; t++)
+                (r = (r << 5) - r + e.charCodeAt(t)), (r |= 0)
+              return t.colors[Math.abs(r) % t.colors.length]
+            }),
+            t.enable(t.load()),
+            t
+          )
+        }
+      },
+      5158: (e, t, r) => {
+        `undefined` == typeof process ||
+        `renderer` === process.type ||
+        !0 === process.browser ||
+        process.__nwjs
+          ? (e.exports = r(1227))
+          : (e.exports = r(39))
+      },
+      39: (e, t, r) => {
+        const n = r(3867),
+          o = r(1669)
+        ;(t.init = function (e) {
+          e.inspectOpts = {}
+          const r = Object.keys(t.inspectOpts)
+          for (let n = 0; n < r.length; n++)
+            e.inspectOpts[r[n]] = t.inspectOpts[r[n]]
+        }),
+          (t.log = function (...e) {
+            return process.stderr.write(o.format(...e) + `\n`)
+          }),
+          (t.formatArgs = function (r) {
+            const { namespace: n, useColors: o } = this
+            if (o) {
+              const t = this.color,
+                o = `[3` + (t < 8 ? t : `8;5;` + t),
+                s = `  ${o};1m${n} [0m`
+              ;(r[0] = s + r[0].split(`\n`).join(`\n` + s)),
+                r.push(o + `m+` + e.exports.humanize(this.diff) + `[0m`)
+            } else
+              r[0] =
+                (t.inspectOpts.hideDate ? `` : new Date().toISOString() + ` `) +
+                n +
+                ` ` +
+                r[0]
+          }),
+          (t.save = function (e) {
+            e ? (process.env.DEBUG = e) : delete process.env.DEBUG
+          }),
+          (t.load = function () {
+            return process.env.DEBUG
+          }),
+          (t.useColors = function () {
+            return `colors` in t.inspectOpts
+              ? Boolean(t.inspectOpts.colors)
+              : n.isatty(process.stderr.fd)
+          }),
+          (t.destroy = o.deprecate(() => {},
+          `Instance method \`debug.destroy()\` is deprecated and no longer does anything. It will be removed in the next major version of \`debug\`.`)),
+          (t.colors = [6, 2, 3, 4, 5, 1])
+        try {
+          const e = r(2130)
+          e &&
+            (e.stderr || e).level >= 2 &&
+            (t.colors = [
+              20,
+              21,
+              26,
+              27,
+              32,
+              33,
+              38,
+              39,
+              40,
+              41,
+              42,
+              43,
+              44,
+              45,
+              56,
+              57,
+              62,
+              63,
+              68,
+              69,
+              74,
+              75,
+              76,
+              77,
+              78,
+              79,
+              80,
+              81,
+              92,
+              93,
+              98,
+              99,
+              112,
+              113,
+              128,
+              129,
+              134,
+              135,
+              148,
+              149,
+              160,
+              161,
+              162,
+              163,
+              164,
+              165,
+              166,
+              167,
+              168,
+              169,
+              170,
+              171,
+              172,
+              173,
+              178,
+              179,
+              184,
+              185,
+              196,
+              197,
+              198,
+              199,
+              200,
+              201,
+              202,
+              203,
+              204,
+              205,
+              206,
+              207,
+              208,
+              209,
+              214,
+              215,
+              220,
+              221,
+            ])
+        } catch (e) {}
+        ;(t.inspectOpts = Object.keys(process.env)
+          .filter((e) => /^debug_/i.test(e))
+          .reduce((e, t) => {
+            const r = t
+              .substring(6)
+              .toLowerCase()
+              .replace(/_([a-z])/g, (e, t) => t.toUpperCase())
+            let n = process.env[t]
+            return (
+              (n =
+                !!/^(yes|on|true|enabled)$/i.test(n) ||
+                (!/^(no|off|false|disabled)$/i.test(n) &&
+                  (`null` === n ? null : Number(n)))),
+              (e[r] = n),
+              e
+            )
+          }, {})),
+          (e.exports = r(2447)(t))
+        const { formatters: s } = e.exports
+        ;(s.o = function (e) {
+          return (
+            (this.inspectOpts.colors = this.useColors),
+            o
+              .inspect(e, this.inspectOpts)
+              .split(`\n`)
+              .map((e) => e.trim())
+              .join(` `)
+          )
+        }),
+          (s.O = function (e) {
+            return (
+              (this.inspectOpts.colors = this.useColors),
+              o.inspect(e, this.inspectOpts)
+            )
+          })
+      },
+      2261: (e, t, r) => {
+        var n
+        e.exports = function () {
+          if (!n)
+            try {
+              n = r(5158)(`follow-redirects`)
+            } catch (e) {
+              n = function () {}
+            }
+          n.apply(null, arguments)
+        }
+      },
+      938: (e, t, r) => {
+        var n = r(8835),
+          o = n.URL,
+          s = r(8605),
+          i = r(7211),
+          a = r(2413).Writable,
+          u = r(2357),
+          c = r(2261),
+          f = [`abort`, `aborted`, `connect`, `error`, `socket`, `timeout`],
+          p = Object.create(null)
+        f.forEach(function (e) {
+          p[e] = function (t, r, n) {
+            this._redirectable.emit(e, t, r, n)
+          }
+        })
+        var l = _(`ERR_FR_REDIRECTION_FAILURE`, ``),
+          d = _(
+            `ERR_FR_TOO_MANY_REDIRECTS`,
+            `Maximum number of redirects exceeded`
+          ),
+          h = _(
+            `ERR_FR_MAX_BODY_LENGTH_EXCEEDED`,
+            `Request body larger than maxBodyLength limit`
+          ),
+          m = _(`ERR_STREAM_WRITE_AFTER_END`, `write after end`)
+        function g(e, t) {
+          a.call(this),
+            this._sanitizeOptions(e),
+            (this._options = e),
+            (this._ended = !1),
+            (this._ending = !1),
+            (this._redirectCount = 0),
+            (this._redirects = []),
+            (this._requestBodyLength = 0),
+            (this._requestBodyBuffers = []),
+            t && this.on(`response`, t)
+          var r = this
+          ;(this._onNativeResponse = function (e) {
+            r._processResponse(e)
+          }),
+            this._performRequest()
+        }
+        function y(e) {
+          var t = { maxRedirects: 21, maxBodyLength: 10485760 },
+            r = {}
+          return (
+            Object.keys(e).forEach(function (s) {
+              var i = s + `:`,
+                a = (r[i] = e[s]),
+                f = (t[s] = Object.create(a))
+              Object.defineProperties(f, {
+                request: {
+                  value: function (e, s, a) {
+                    if (`string` == typeof e) {
+                      var f = e
+                      try {
+                        e = C(new o(f))
+                      } catch (t) {
+                        e = n.parse(f)
+                      }
+                    } else
+                      o && e instanceof o
+                        ? (e = C(e))
+                        : ((a = s), (s = e), (e = { protocol: i }))
+                    return (
+                      `function` == typeof s && ((a = s), (s = null)),
+                      ((s = Object.assign(
+                        {
+                          maxRedirects: t.maxRedirects,
+                          maxBodyLength: t.maxBodyLength,
+                        },
+                        e,
+                        s
+                      )).nativeProtocols = r),
+                      u.equal(s.protocol, i, `protocol mismatch`),
+                      c(`options`, s),
+                      new g(s, a)
+                    )
+                  },
+                  configurable: !0,
+                  enumerable: !0,
+                  writable: !0,
+                },
+                get: {
+                  value: function (e, t, r) {
+                    var n = f.request(e, t, r)
+                    return n.end(), n
+                  },
+                  configurable: !0,
+                  enumerable: !0,
+                  writable: !0,
+                },
+              })
+            }),
+            t
+          )
+        }
+        function v() {}
+        function C(e) {
+          var t = {
+            protocol: e.protocol,
+            hostname: e.hostname.startsWith(`[`)
+              ? e.hostname.slice(1, -1)
+              : e.hostname,
+            hash: e.hash,
+            search: e.search,
+            pathname: e.pathname,
+            path: e.pathname + e.search,
+            href: e.href,
+          }
+          return `` !== e.port && (t.port = Number(e.port)), t
+        }
+        function b(e, t) {
+          var r
+          for (var n in t) e.test(n) && ((r = t[n]), delete t[n])
+          return r
+        }
+        function _(e, t) {
+          function r(e) {
+            Error.captureStackTrace(this, this.constructor),
+              (this.message = e || t)
+          }
+          return (
+            (r.prototype = new Error()),
+            (r.prototype.constructor = r),
+            (r.prototype.name = `Error [` + e + `]`),
+            (r.prototype.code = e),
+            r
+          )
+        }
+        function x(e) {
+          for (var t = 0; t < f.length; t++) e.removeListener(f[t], p[f[t]])
+          e.on(`error`, v), e.abort()
+        }
+        ;(g.prototype = Object.create(a.prototype)),
+          (g.prototype.abort = function () {
+            x(this._currentRequest),
+              this.emit(`abort`),
+              this.removeAllListeners()
+          }),
+          (g.prototype.write = function (e, t, r) {
+            if (this._ending) throw new m()
+            if (
+              !(`string` == typeof e || (`object` == typeof e && `length` in e))
+            )
+              throw new TypeError(
+                `data should be a string, Buffer or Uint8Array`
+              )
+            `function` == typeof t && ((r = t), (t = null)),
+              0 !== e.length
+                ? this._requestBodyLength + e.length <=
+                  this._options.maxBodyLength
+                  ? ((this._requestBodyLength += e.length),
+                    this._requestBodyBuffers.push({ data: e, encoding: t }),
+                    this._currentRequest.write(e, t, r))
+                  : (this.emit(`error`, new h()), this.abort())
+                : r && r()
+          }),
+          (g.prototype.end = function (e, t, r) {
+            if (
+              (`function` == typeof e
+                ? ((r = e), (e = t = null))
+                : `function` == typeof t && ((r = t), (t = null)),
+              e)
+            ) {
+              var n = this,
+                o = this._currentRequest
+              this.write(e, t, function () {
+                ;(n._ended = !0), o.end(null, null, r)
+              }),
+                (this._ending = !0)
+            } else
+              (this._ended = this._ending = !0),
+                this._currentRequest.end(null, null, r)
+          }),
+          (g.prototype.setHeader = function (e, t) {
+            ;(this._options.headers[e] = t),
+              this._currentRequest.setHeader(e, t)
+          }),
+          (g.prototype.removeHeader = function (e) {
+            delete this._options.headers[e],
+              this._currentRequest.removeHeader(e)
+          }),
+          (g.prototype.setTimeout = function (e, t) {
+            var r = this
+            function n(t) {
+              t.setTimeout(e),
+                t.removeListener(`timeout`, t.destroy),
+                t.addListener(`timeout`, t.destroy)
+            }
+            function o(t) {
+              r._timeout && clearTimeout(r._timeout),
+                (r._timeout = setTimeout(function () {
+                  r.emit(`timeout`), s()
+                }, e)),
+                n(t)
+            }
+            function s() {
+              clearTimeout(this._timeout),
+                t && r.removeListener(`timeout`, t),
+                this.socket || r._currentRequest.removeListener(`socket`, o)
+            }
+            return (
+              t && this.on(`timeout`, t),
+              this.socket
+                ? o(this.socket)
+                : this._currentRequest.once(`socket`, o),
+              this.on(`socket`, n),
+              this.once(`response`, s),
+              this.once(`error`, s),
+              this
+            )
+          }),
+          [
+            `flushHeaders`,
+            `getHeader`,
+            `setNoDelay`,
+            `setSocketKeepAlive`,
+          ].forEach(function (e) {
+            g.prototype[e] = function (t, r) {
+              return this._currentRequest[e](t, r)
+            }
+          }),
+          [`aborted`, `connection`, `socket`].forEach(function (e) {
+            Object.defineProperty(g.prototype, e, {
+              get: function () {
+                return this._currentRequest[e]
+              },
+            })
+          }),
+          (g.prototype._sanitizeOptions = function (e) {
+            if (
+              (e.headers || (e.headers = {}),
+              e.host && (e.hostname || (e.hostname = e.host), delete e.host),
+              !e.pathname && e.path)
+            ) {
+              var t = e.path.indexOf(`?`)
+              t < 0
+                ? (e.pathname = e.path)
+                : ((e.pathname = e.path.substring(0, t)),
+                  (e.search = e.path.substring(t)))
+            }
+          }),
+          (g.prototype._performRequest = function () {
+            var e = this._options.protocol,
+              t = this._options.nativeProtocols[e]
+            if (t) {
+              if (this._options.agents) {
+                var r = e.substr(0, e.length - 1)
+                this._options.agent = this._options.agents[r]
+              }
+              var o = (this._currentRequest = t.request(
+                this._options,
+                this._onNativeResponse
+              ))
+              ;(this._currentUrl = n.format(this._options)),
+                (o._redirectable = this)
+              for (var s = 0; s < f.length; s++) o.on(f[s], p[f[s]])
+              if (this._isRedirect) {
+                var i = 0,
+                  a = this,
+                  u = this._requestBodyBuffers
+                !(function e(t) {
+                  if (o === a._currentRequest)
+                    if (t) a.emit(`error`, t)
+                    else if (i < u.length) {
+                      var r = u[i++]
+                      o.finished || o.write(r.data, r.encoding, e)
+                    } else a._ended && o.end()
+                })()
+              }
+            } else
+              this.emit(`error`, new TypeError(`Unsupported protocol ` + e))
+          }),
+          (g.prototype._processResponse = function (e) {
+            var t = e.statusCode
+            this._options.trackRedirects &&
+              this._redirects.push({
+                url: this._currentUrl,
+                headers: e.headers,
+                statusCode: t,
+              })
+            var r = e.headers.location
+            if (
+              r &&
+              !1 !== this._options.followRedirects &&
+              t >= 300 &&
+              t < 400
+            ) {
+              if (
+                (x(this._currentRequest),
+                e.destroy(),
+                ++this._redirectCount > this._options.maxRedirects)
+              )
+                return void this.emit(`error`, new d())
+              ;(((301 === t || 302 === t) && `POST` === this._options.method) ||
+                (303 === t && !/^(?:GET|HEAD)$/.test(this._options.method))) &&
+                ((this._options.method = `GET`),
+                (this._requestBodyBuffers = []),
+                b(/^content-/i, this._options.headers))
+              var o =
+                  b(/^host$/i, this._options.headers) ||
+                  n.parse(this._currentUrl).hostname,
+                s = n.resolve(this._currentUrl, r)
+              c(`redirecting to`, s), (this._isRedirect = !0)
+              var i = n.parse(s)
+              if (
+                (Object.assign(this._options, i),
+                i.hostname !== o &&
+                  b(/^authorization$/i, this._options.headers),
+                `function` == typeof this._options.beforeRedirect)
+              ) {
+                var a = { headers: e.headers }
+                try {
+                  this._options.beforeRedirect.call(null, this._options, a)
+                } catch (e) {
+                  return void this.emit(`error`, e)
+                }
+                this._sanitizeOptions(this._options)
+              }
+              try {
+                this._performRequest()
+              } catch (e) {
+                var u = new l(`Redirected request failed: ` + e.message)
+                ;(u.cause = e), this.emit(`error`, u)
+              }
+            } else
+              (e.responseUrl = this._currentUrl),
+                (e.redirects = this._redirects),
+                this.emit(`response`, e),
+                (this._requestBodyBuffers = [])
+          }),
+          (e.exports = y({ http: s, https: i })),
+          (e.exports.wrap = y)
+      },
+      6560: (e) => {
+        "use strict"
+        e.exports = (e, t = process.argv) => {
+          const r = e.startsWith(`-`) ? `` : 1 === e.length ? `-` : `--`,
+            n = t.indexOf(r + e),
+            o = t.indexOf(`--`)
+          return -1 !== n && (-1 === o || n < o)
+        }
+      },
+      7418: (e) => {
+        "use strict"
+        var t = Object.getOwnPropertySymbols,
+          r = Object.prototype.hasOwnProperty,
+          n = Object.prototype.propertyIsEnumerable
+        function o(e) {
+          if (null == e)
+            throw new TypeError(
+              `Object.assign cannot be called with null or undefined`
+            )
+          return Object(e)
+        }
+        e.exports = (function () {
+          try {
+            if (!Object.assign) return !1
+            var e = new String(`abc`)
+            if (((e[5] = `de`), `5` === Object.getOwnPropertyNames(e)[0]))
+              return !1
+            for (var t = {}, r = 0; r < 10; r++)
+              t[`_` + String.fromCharCode(r)] = r
+            if (
+              `0123456789` !==
+              Object.getOwnPropertyNames(t)
+                .map(function (e) {
+                  return t[e]
+                })
+                .join(``)
+            )
+              return !1
+            var n = {}
+            return (
+              `abcdefghijklmnopqrst`.split(``).forEach(function (e) {
+                n[e] = e
+              }),
+              `abcdefghijklmnopqrst` ===
+                Object.keys(Object.assign({}, n)).join(``)
+            )
+          } catch (e) {
+            return !1
+          }
+        })()
+          ? Object.assign
+          : function (e, s) {
+              for (var i, a, u = o(e), c = 1; c < arguments.length; c++) {
+                for (var f in (i = Object(arguments[c])))
+                  r.call(i, f) && (u[f] = i[f])
+                if (t) {
+                  a = t(i)
+                  for (var p = 0; p < a.length; p++)
+                    n.call(i, a[p]) && (u[a[p]] = i[a[p]])
+                }
+              }
+              return u
+            }
+      },
+      2408: (e, t, r) => {
+        "use strict"
+        var n = r(7418),
+          o = 60103,
+          s = 60106
+        ;(t.Fragment = 60107), (t.StrictMode = 60108), (t.Profiler = 60114)
+        var i = 60109,
+          a = 60110,
+          u = 60112
+        t.Suspense = 60113
+        var c = 60115,
+          f = 60116
+        if (`function` == typeof Symbol && Symbol.for) {
+          var p = Symbol.for
+          ;(o = p(`react.element`)),
+            (s = p(`react.portal`)),
+            (t.Fragment = p(`react.fragment`)),
+            (t.StrictMode = p(`react.strict_mode`)),
+            (t.Profiler = p(`react.profiler`)),
+            (i = p(`react.provider`)),
+            (a = p(`react.context`)),
+            (u = p(`react.forward_ref`)),
+            (t.Suspense = p(`react.suspense`)),
+            (c = p(`react.memo`)),
+            (f = p(`react.lazy`))
+        }
+        var l = `function` == typeof Symbol && Symbol.iterator
+        function d(e) {
+          for (
+            var t =
+                `https://reactjs.org/docs/error-decoder.html?invariant=` + e,
+              r = 1;
+            r < arguments.length;
+            r++
+          )
+            t += `&args[]=` + encodeURIComponent(arguments[r])
+          return (
+            `Minified React error #` +
+            e +
+            `; visit ` +
+            t +
+            ` for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`
+          )
+        }
+        var h = {
+            isMounted: function () {
+              return !1
+            },
+            enqueueForceUpdate: function () {},
+            enqueueReplaceState: function () {},
+            enqueueSetState: function () {},
+          },
+          m = {}
+        function g(e, t, r) {
+          ;(this.props = e),
+            (this.context = t),
+            (this.refs = m),
+            (this.updater = r || h)
+        }
+        function y() {}
+        function v(e, t, r) {
+          ;(this.props = e),
+            (this.context = t),
+            (this.refs = m),
+            (this.updater = r || h)
+        }
+        ;(g.prototype.isReactComponent = {}),
+          (g.prototype.setState = function (e, t) {
+            if (`object` != typeof e && `function` != typeof e && null != e)
+              throw Error(d(85))
+            this.updater.enqueueSetState(this, e, t, `setState`)
+          }),
+          (g.prototype.forceUpdate = function (e) {
+            this.updater.enqueueForceUpdate(this, e, `forceUpdate`)
+          }),
+          (y.prototype = g.prototype)
+        var C = (v.prototype = new y())
+        ;(C.constructor = v), n(C, g.prototype), (C.isPureReactComponent = !0)
+        var b = { current: null },
+          _ = Object.prototype.hasOwnProperty,
+          x = { key: !0, ref: !0, __self: !0, __source: !0 }
+        function w(e, t, r) {
+          var n,
+            s = {},
+            i = null,
+            a = null
+          if (null != t)
+            for (n in (void 0 !== t.ref && (a = t.ref),
+            void 0 !== t.key && (i = `` + t.key),
+            t))
+              _.call(t, n) && !x.hasOwnProperty(n) && (s[n] = t[n])
+          var u = arguments.length - 2
+          if (1 === u) s.children = r
+          else if (1 < u) {
+            for (var c = Array(u), f = 0; f < u; f++) c[f] = arguments[f + 2]
+            s.children = c
+          }
+          if (e && e.defaultProps)
+            for (n in (u = e.defaultProps)) void 0 === s[n] && (s[n] = u[n])
+          return {
+            $$typeof: o,
+            type: e,
+            key: i,
+            ref: a,
+            props: s,
+            _owner: b.current,
+          }
+        }
+        function R(e) {
+          return `object` == typeof e && null !== e && e.$$typeof === o
+        }
+        var E = /\/+/g
+        function O(e, t) {
+          return `object` == typeof e && null !== e && null != e.key
+            ? (function (e) {
+                var t = { "=": `=0`, ":": `=2` }
+                return (
+                  `$` +
+                  e.replace(/[=:]/g, function (e) {
+                    return t[e]
+                  })
+                )
+              })(`` + e.key)
+            : t.toString(36)
+        }
+        function j(e, t, r, n, i) {
+          var a = typeof e
+          ;(`undefined` !== a && `boolean` !== a) || (e = null)
+          var u = !1
+          if (null === e) u = !0
+          else
+            switch (a) {
+              case `string`:
+              case `number`:
+                u = !0
+                break
+              case `object`:
+                switch (e.$$typeof) {
+                  case o:
+                  case s:
+                    u = !0
+                }
+            }
+          if (u)
+            return (
+              (i = i((u = e))),
+              (e = `` === n ? `.` + O(u, 0) : n),
+              Array.isArray(i)
+                ? ((r = ``),
+                  null != e && (r = e.replace(E, `$&/`) + `/`),
+                  j(i, t, r, ``, function (e) {
+                    return e
+                  }))
+                : null != i &&
+                  (R(i) &&
+                    (i = (function (e, t) {
+                      return {
+                        $$typeof: o,
+                        type: e.type,
+                        key: t,
+                        ref: e.ref,
+                        props: e.props,
+                        _owner: e._owner,
+                      }
+                    })(
+                      i,
+                      r +
+                        (!i.key || (u && u.key === i.key)
+                          ? ``
+                          : (`` + i.key).replace(E, `$&/`) + `/`) +
+                        e
+                    )),
+                  t.push(i)),
+              1
+            )
+          if (((u = 0), (n = `` === n ? `.` : n + `:`), Array.isArray(e)))
+            for (var c = 0; c < e.length; c++) {
+              var f = n + O((a = e[c]), c)
+              u += j(a, t, r, f, i)
+            }
+          else if (
+            `function` ==
+            typeof (f = (function (e) {
+              return null === e || `object` != typeof e
+                ? null
+                : `function` == typeof (e = (l && e[l]) || e[`@@iterator`])
+                ? e
+                : null
+            })(e))
+          )
+            for (e = f.call(e), c = 0; !(a = e.next()).done; )
+              u += j((a = a.value), t, r, (f = n + O(a, c++)), i)
+          else if (`object` === a)
+            throw (
+              ((t = `` + e),
+              Error(
+                d(
+                  31,
+                  `[object Object]` === t
+                    ? `object with keys {` + Object.keys(e).join(`, `) + `}`
+                    : t
+                )
+              ))
+            )
+          return u
+        }
+        function F(e, t, r) {
+          if (null == e) return e
+          var n = [],
+            o = 0
+          return (
+            j(e, n, ``, ``, function (e) {
+              return t.call(r, e, o++)
+            }),
+            n
+          )
+        }
+        function k(e) {
+          if (-1 === e._status) {
+            var t = e._result
+            ;(t = t()),
+              (e._status = 0),
+              (e._result = t),
+              t.then(
+                function (t) {
+                  0 === e._status &&
+                    ((t = t.default), (e._status = 1), (e._result = t))
+                },
+                function (t) {
+                  0 === e._status && ((e._status = 2), (e._result = t))
+                }
+              )
+          }
+          if (1 === e._status) return e._result
+          throw e._result
+        }
+        var A = { current: null }
+        function S() {
+          var e = A.current
+          if (null === e) throw Error(d(321))
+          return e
+        }
+        var T = {
+          ReactCurrentDispatcher: A,
+          ReactCurrentBatchConfig: { transition: 0 },
+          ReactCurrentOwner: b,
+          IsSomeRendererActing: { current: !1 },
+          assign: n,
+        }
+        ;(t.Children = {
+          map: F,
+          forEach: function (e, t, r) {
+            F(
+              e,
+              function () {
+                t.apply(this, arguments)
+              },
+              r
+            )
+          },
+          count: function (e) {
+            var t = 0
+            return (
+              F(e, function () {
+                t++
+              }),
+              t
+            )
+          },
+          toArray: function (e) {
+            return (
+              F(e, function (e) {
+                return e
+              }) || []
+            )
+          },
+          only: function (e) {
+            if (!R(e)) throw Error(d(143))
+            return e
+          },
+        }),
+          (t.Component = g),
+          (t.PureComponent = v),
+          (t.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = T),
+          (t.cloneElement = function (e, t, r) {
+            if (null == e) throw Error(d(267, e))
+            var s = n({}, e.props),
+              i = e.key,
+              a = e.ref,
+              u = e._owner
+            if (null != t) {
+              if (
+                (void 0 !== t.ref && ((a = t.ref), (u = b.current)),
+                void 0 !== t.key && (i = `` + t.key),
+                e.type && e.type.defaultProps)
+              )
+                var c = e.type.defaultProps
+              for (f in t)
+                _.call(t, f) &&
+                  !x.hasOwnProperty(f) &&
+                  (s[f] = void 0 === t[f] && void 0 !== c ? c[f] : t[f])
+            }
+            var f = arguments.length - 2
+            if (1 === f) s.children = r
+            else if (1 < f) {
+              c = Array(f)
+              for (var p = 0; p < f; p++) c[p] = arguments[p + 2]
+              s.children = c
+            }
+            return {
+              $$typeof: o,
+              type: e.type,
+              key: i,
+              ref: a,
+              props: s,
+              _owner: u,
+            }
+          }),
+          (t.createContext = function (e, t) {
+            return (
+              void 0 === t && (t = null),
+              ((e = {
+                $$typeof: a,
+                _calculateChangedBits: t,
+                _currentValue: e,
+                _currentValue2: e,
+                _threadCount: 0,
+                Provider: null,
+                Consumer: null,
+              }).Provider = { $$typeof: i, _context: e }),
+              (e.Consumer = e)
+            )
+          }),
+          (t.createElement = w),
+          (t.createFactory = function (e) {
+            var t = w.bind(null, e)
+            return (t.type = e), t
+          }),
+          (t.createRef = function () {
+            return { current: null }
+          }),
+          (t.forwardRef = function (e) {
+            return { $$typeof: u, render: e }
+          }),
+          (t.isValidElement = R),
+          (t.lazy = function (e) {
+            return {
+              $$typeof: f,
+              _payload: { _status: -1, _result: e },
+              _init: k,
+            }
+          }),
+          (t.memo = function (e, t) {
+            return { $$typeof: c, type: e, compare: void 0 === t ? null : t }
+          }),
+          (t.useCallback = function (e, t) {
+            return S().useCallback(e, t)
+          }),
+          (t.useContext = function (e, t) {
+            return S().useContext(e, t)
+          }),
+          (t.useDebugValue = function () {}),
+          (t.useEffect = function (e, t) {
+            return S().useEffect(e, t)
+          }),
+          (t.useImperativeHandle = function (e, t, r) {
+            return S().useImperativeHandle(e, t, r)
+          }),
+          (t.useLayoutEffect = function (e, t) {
+            return S().useLayoutEffect(e, t)
+          }),
+          (t.useMemo = function (e, t) {
+            return S().useMemo(e, t)
+          }),
+          (t.useReducer = function (e, t, r) {
+            return S().useReducer(e, t, r)
+          }),
+          (t.useRef = function (e) {
+            return S().useRef(e)
+          }),
+          (t.useState = function (e) {
+            return S().useState(e)
+          }),
+          (t.version = `17.0.2`)
+      },
+      7294: (e, t, r) => {
+        "use strict"
+        e.exports = r(2408)
+      },
+      2130: (e, t, r) => {
+        "use strict"
+        const n = r(2087),
+          o = r(3867),
+          s = r(6560),
+          { env: i } = process
+        let a
+        function u(e) {
+          return (
+            0 !== e && {
+              level: e,
+              hasBasic: !0,
+              has256: e >= 2,
+              has16m: e >= 3,
+            }
+          )
+        }
+        function c(e, t) {
+          if (0 === a) return 0
+          if (s(`color=16m`) || s(`color=full`) || s(`color=truecolor`))
+            return 3
+          if (s(`color=256`)) return 2
+          if (e && !t && void 0 === a) return 0
+          const r = a || 0
+          if (`dumb` === i.TERM) return r
+          if (`win32` === process.platform) {
+            const e = n.release().split(`.`)
+            return Number(e[0]) >= 10 && Number(e[2]) >= 10586
+              ? Number(e[2]) >= 14931
+                ? 3
+                : 2
+              : 1
+          }
+          if (`CI` in i)
+            return [
+              `TRAVIS`,
+              `CIRCLECI`,
+              `APPVEYOR`,
+              `GITLAB_CI`,
+              `GITHUB_ACTIONS`,
+              `BUILDKITE`,
+            ].some((e) => e in i) || `codeship` === i.CI_NAME
+              ? 1
+              : r
+          if (`TEAMCITY_VERSION` in i)
+            return /^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/.test(i.TEAMCITY_VERSION)
+              ? 1
+              : 0
+          if (`truecolor` === i.COLORTERM) return 3
+          if (`TERM_PROGRAM` in i) {
+            const e = parseInt((i.TERM_PROGRAM_VERSION || ``).split(`.`)[0], 10)
+            switch (i.TERM_PROGRAM) {
+              case `iTerm.app`:
+                return e >= 3 ? 3 : 2
+              case `Apple_Terminal`:
+                return 2
+            }
+          }
+          return /-256(color)?$/i.test(i.TERM)
+            ? 2
+            : /^screen|^xterm|^vt100|^vt220|^rxvt|color|ansi|cygwin|linux/i.test(
+                i.TERM
+              ) || `COLORTERM` in i
+            ? 1
+            : r
+        }
+        s(`no-color`) || s(`no-colors`) || s(`color=false`) || s(`color=never`)
+          ? (a = 0)
+          : (s(`color`) ||
+              s(`colors`) ||
+              s(`color=true`) ||
+              s(`color=always`)) &&
+            (a = 1),
+          `FORCE_COLOR` in i &&
+            (a =
+              `true` === i.FORCE_COLOR
+                ? 1
+                : `false` === i.FORCE_COLOR
+                ? 0
+                : 0 === i.FORCE_COLOR.length
+                ? 1
+                : Math.min(parseInt(i.FORCE_COLOR, 10), 3)),
+          (e.exports = {
+            supportsColor: function (e) {
+              return u(c(e, e && e.isTTY))
+            },
+            stdout: u(c(!0, o.isatty(1))),
+            stderr: u(c(!0, o.isatty(2))),
+          })
+      },
+      1629: function (e, t, r) {
+        "use strict"
+        var n =
+          (this && this.__importDefault) ||
+          function (e) {
+            return e && e.__esModule ? e : { default: e }
+          }
+        Object.defineProperty(t, `__esModule`, { value: !0 }),
+          (t.useContentMap = void 0)
+        var o = r(7294),
+          s = n(r(9669))
+        t.useContentMap = function (e) {
+          var t = o.useState({}),
+            r = t[0],
+            n = t[1]
+          return (
+            o.useEffect(
+              function () {
+                s.default
+                  .get(`http://localhost:3000/content-map`)
+                  .then(function (e) {
+                    var t = e.data
+                    n(t)
+                  })
+              },
+              [e.watch]
+            ),
+            r
+          )
+        }
+      },
+      2357: (e) => {
+        "use strict"
+        e.exports = require(`assert`)
+      },
+      8605: (e) => {
+        "use strict"
+        e.exports = require(`http`)
+      },
+      7211: (e) => {
+        "use strict"
+        e.exports = require(`https`)
+      },
+      2087: (e) => {
+        "use strict"
+        e.exports = require(`os`)
+      },
+      2413: (e) => {
+        "use strict"
+        e.exports = require(`stream`)
+      },
+      3867: (e) => {
+        "use strict"
+        e.exports = require(`tty`)
+      },
+      8835: (e) => {
+        "use strict"
+        e.exports = require(`url`)
+      },
+      1669: (e) => {
+        "use strict"
+        e.exports = require(`util`)
+      },
+      8761: (e) => {
+        "use strict"
+        e.exports = require(`zlib`)
+      },
+    },
+    t = {}
+  !(function r(n) {
+    var o = t[n]
+    if (void 0 !== o) return o.exports
+    var s = (t[n] = { exports: {} })
+    return e[n].call(s.exports, s, s.exports, r), s.exports
+  })(1629)
+})()

--- a/bin/script.sh
+++ b/bin/script.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env node
-
-require = require('esm')(module /*, options*/);
-require('../out/cli/src/main').cli(process.argv);

--- a/build-tsconfig.json
+++ b/build-tsconfig.json
@@ -1,6 +1,4 @@
 {
-  "include": ["packages/**/*"],
-  "exclude": ["node_modules", "out"],
   "compilerOptions": {
     "jsx": "react",
     "target": "es5",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "minecraft-asset-reader",
-  "version": "0.1.0-alpha",
-  "description": "Read in textures from a minecraft texture pack",
+  "name": "@nuggylib/minecraft-asset-reader",
+  "version": "0.1.1-alpha",
+  "description": "A tool to configure starter site content for a Minecraft mod or modpack and upload it to Sanity",
   "main": "packages/cli/src/main.tsx",
   "bin": {
-    "minecraft-asset-reader": "bin/script.sh"
+    "minecraft-asset-reader": "bin/minecraft-asset-reader"
   },
   "publishConfig": {
     "access": "public"
@@ -14,14 +14,17 @@
     "minecraft-asset-reader"
   ],
   "scripts": {
-    "clean": "rm -rf out/ dist/ node_modules packages/cli/node_modules packages/client/node_modules",
-    "reset": "yarn clean && yarn && yarn lerna bootstrap && cd packages/cli && yarn && cd ../client && yarn",
+    "clean": "rm -rf out/ dist/",
+    "clean-modules": "rm -rf node_modules packages/cli/node_modules packages/client/node_modules",
+    "reset": "yarn clean && yarn clean-modules && yarn && yarn lerna bootstrap && cd packages/cli && yarn && cd ../client && yarn",
     "clear-db": "rm -rf /tmp/minecraft-asset-reader",
     "lint:commit": "prettier-eslint \"{src/**/*,test/**/*,packages/**/*}.{ts,tsx}\" --eslint-config-path=.eslintrc.yml --write",
     "prepare": "husky install",
     "reset-db": "rm -rf /tmp/minecraft-asset-reader",
     "run-app": "LOCAL_BUILD=true node out/cli/src/main.js",
     "build-app": "yarn build:cli && yarn build:client",
+    "build-package": "node scripts/pack.js",
+    "build": "yarn build-app && lerna exec --scope 'minecraft-asset-reader' yarn package-yarn && yarn build-package",
     "start:cli": "lerna exec --scope 'minecraft-asset-reader' yarn start",
     "build:cli": "lerna exec --scope 'minecraft-asset-reader' yarn build && cd out/ && rm -rf client/ && cd .. && cp packages/cli/package.json out/cli && cd out/cli && npm install",
     "start:client": "lerna exec --scope 'minecraft-asset-reader-webapp' yarn start",
@@ -38,7 +41,6 @@
   },
   "homepage": "https://github.com/nuggylib/minecraft-asset-reader#readme",
   "devDependencies": {
-    "@babel/preset-env": "^7.13.15",
     "@babel/preset-react": "^7.13.13",
     "@emotion/eslint-plugin": "^11.2.0",
     "@testing-library/react-hooks": "^5.1.1",
@@ -69,15 +71,18 @@
     "eslint-plugin-react": "^7.23.1",
     "eslint-plugin-react-hooks": "^4.2.0",
     "husky": "^6.0.0",
+    "klaw-sync": "^6.0.0",
     "lerna": "^4.0.0",
     "lint-staged": ">=10",
     "prettier": "^2.2.1",
     "prettier-eslint-cli": "^5.0.1",
     "react-test-renderer": "^16.8.2",
     "ts-jest": "^26.5.4",
+    "ts-loader": "^9.2.3",
     "ts-node": "^9.1.1",
     "typedoc": "^0.20.30",
-    "typescript": "^4.2.3"
+    "typescript": "^4.2.3",
+    "webpack": "^5.38.1"
   },
   "dependencies": {
     "dotenv": "^9.0.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
   "name": "minecraft-asset-reader",
   "version": "0.1.0-alpha",
   "description": "Read in textures from a minecraft texture pack",
-  "main": "src/main.tsx",
+  "main": "out/cli/src/main.js",
   "bin": {
     "minecraft-asset-reader": "bin/script.sh"
   },
@@ -13,11 +13,13 @@
     "cli",
     "minecraft-asset-reader"
   ],
+  "type": "module",
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf out/ dist/",
     "reset": "yarn clean && npm run build",
     "lint:commit": "prettier-eslint \"{src/**/*,test/**/*,packages/**/*}.{ts,tsx}\" --eslint-config-path=.eslintrc.yml --write",
+    "package-yarn": "node src/scripts/package-yarn.js",
     "test": "jest --verbose=false",
     "coverage": "jest --coverage",
     "start": "LOCAL=true ts-node ./src/main.tsx"
@@ -45,6 +47,7 @@
     "esm": "^3.2.25",
     "express": "^4.17.1",
     "express-paginate": "^1.0.2",
+    "fs-extra": "^10.0.0",
     "ink": "^3.0.8",
     "ink-big-text": "^1.2.0",
     "ink-divider": "^3.0.0",
@@ -68,10 +71,13 @@
     "util": "^0.12.3"
   },
   "devDependencies": {
+    "@types/fs-extra": "^9.0.11",
     "@types/react": ">=16.8.0",
     "@types/sqlite3": "^3.1.7",
     "@types/unzipper": "^0.10.3",
     "bufferutil": "^4.0.1",
+    "simple-get": "^4.0.0",
+    "ts-loader": "^9.2.3",
     "utf-8-validate": "^5.0.2"
   }
 }

--- a/packages/cli/src/scripts/package-yarn.js
+++ b/packages/cli/src/scripts/package-yarn.js
@@ -1,0 +1,64 @@
+/* eslint-disable no-console */
+const path = require(`path`)
+const fse = require(`fs-extra`)
+const simpleGet = require(`simple-get`)
+
+const version = `1.22.10`
+const baseUrl = `https://github.com/yarnpkg/yarn/releases/download`
+const bundleUrl = `${baseUrl}/v${version}/yarn-legacy-${version}.js`
+const licenseUrl = `https://raw.githubusercontent.com/yarnpkg/yarn/master/LICENSE`
+const destination = path.join(__dirname, `..`, `..`, `vendor`, `yarn`)
+const writeFlags = { encoding: `utf8`, mode: 0o755 }
+const request = (url) =>
+  new Promise((resolve, reject) =>
+    simpleGet.concat(url, (err, res, body) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(body.toString())
+      }
+    })
+  )
+
+function download() {
+  console.log(`[package-yarn] Downloading bundle`)
+  simpleGet(bundleUrl, (err, res) => {
+    if (err) {
+      throw err
+    }
+
+    res.pipe(
+      fse.createWriteStream(destination, writeFlags).on(`close`, writeHeader)
+    )
+  })
+}
+
+async function writeHeader() {
+  console.log(`[package-yarn] Downloading license`)
+  const license = await request(licenseUrl)
+  const commented = license
+    .split(`\n`)
+    .map((line) => ` * ${line}`)
+    .join(`\n`)
+  const wrappedLicense = `/*\n${commented}*/`
+
+  console.log(`[package-yarn] Reading bundle`)
+  const bundle = await fse.readFile(destination, writeFlags)
+  if (bundle[0] !== `#` && bundle[1] !== `!`) {
+    throw new Error(
+      `[package-yarn] Expected bundle to start with a shebang (#!), but it did not`
+    )
+  }
+
+  console.log(`[package-yarn] Writing modified bundle`)
+  const pkgDate = new Date().toISOString().substr(0, 10)
+  const versionString = `/* yarn v${version} - packaged ${pkgDate} */`
+  const licensed = bundle.replace(
+    /^(#!.*\n)/,
+    `$1${versionString}\n${wrappedLicense}\n\n`
+  )
+  await fse.writeFile(destination, licensed, writeFlags)
+  console.log(`[package-yarn] Complete!`)
+}
+
+download()

--- a/packages/cli/yarn.lock
+++ b/packages/cli/yarn.lock
@@ -85,6 +85,13 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/fs-extra@^9.0.11":
+  version "9.0.11"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.11.tgz#8cc99e103499eab9f347dbc6ca4e99fb8d2c2b87"
+  integrity sha512-mZsifGG4QeQ7hlkhO56u7zt/ycBgGxSVsFI/6lGTU34VtwkiqrrSDgw0+ygs8kFGWcXnFQWMrzF2h7TtDFNixA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/mime@^1":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
@@ -397,6 +404,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+braces@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+  dependencies:
+    fill-range "^7.0.1"
+
 buffer-indexof-polyfill@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz#d2732135c5999c64b277fcf9b1abe3498254729c"
@@ -673,6 +687,13 @@ decompress-response@^4.2.0:
   dependencies:
     mimic-response "^2.0.0"
 
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
 decompress-zip@^0.3.2:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/decompress-zip/-/decompress-zip-0.3.3.tgz#71469aca39003e360a4044d6a6a9f64a1bef5a49"
@@ -786,6 +807,14 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
+
+enhanced-resolve@^5.0.0:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz#15ddc779345cbb73e97c611cd00c01c1e7bf4d8b"
+  integrity sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
 
 es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next.2:
   version "1.18.0"
@@ -937,6 +966,13 @@ figures@^3.0.0, figures@^3.2.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
+fill-range@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
 finalhandler@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
@@ -1005,6 +1041,15 @@ from2@^2.1.1:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
+
+fs-extra@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
+  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-minipass@^1.2.5:
   version "1.2.7"
@@ -1100,7 +1145,7 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.2.2:
+graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
@@ -1454,6 +1499,11 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
 is-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
@@ -1564,6 +1614,15 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -1628,6 +1687,13 @@ loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 make-error@^1.3.0:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
@@ -1647,6 +1713,14 @@ methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
+
+micromatch@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
+  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.2.3"
 
 mime-db@1.47.0:
   version "1.47.0"
@@ -1679,6 +1753,11 @@ mimic-response@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
   integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
+
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -2014,6 +2093,11 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
+picomatch@^2.2.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
+  integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -2300,6 +2384,13 @@ semver@^5.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
+semver@^7.3.4:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"
@@ -2374,6 +2465,15 @@ simple-get@^3.0.3:
   integrity sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==
   dependencies:
     decompress-response "^4.2.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
+simple-get@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.0.tgz#73fa628278d21de83dadd5512d2cc1f4872bd675"
+  integrity sha512-ZalZGexYr3TA0SwySsr5HlgOOinS4Jsa8YB2GJ6lUNAazyAu4KG/VmzMTwAt2YVXzzVj8QmefmAonZIK2BSGcQ==
+  dependencies:
+    decompress-response "^6.0.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
 
@@ -2554,6 +2654,11 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+tapable@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
+  integrity sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==
+
 tar@^4, tar@^4.4.2:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
@@ -2600,6 +2705,13 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+  dependencies:
+    is-number "^7.0.0"
+
 toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
@@ -2624,6 +2736,16 @@ tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
   integrity sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=
+
+ts-loader@^9.2.3:
+  version "9.2.3"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.2.3.tgz#dc3b6362a4d4382493cd4f138d345f419656de68"
+  integrity sha512-sEyWiU3JMHBL55CIeC4iqJQadI0U70A5af0kvgbNLHVNz2ACztQg0j/9x10bjjIht8WfFYLKfn4L6tkZ+pu+8Q==
+  dependencies:
+    chalk "^4.1.0"
+    enhanced-resolve "^5.0.0"
+    micromatch "^4.0.0"
+    semver "^7.3.4"
 
 tslib@^1.9.0:
   version "1.14.1"
@@ -2679,6 +2801,11 @@ unbox-primitive@^1.0.0:
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
@@ -2847,6 +2974,11 @@ yallist@^3.0.0, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yoga-layout-prebuilt@^1.9.6:
   version "1.10.0"

--- a/scripts/pack.js
+++ b/scripts/pack.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/* eslint-disable no-console, no-process-exit, no-sync */
+const path = require(`path`)
+const fse = require(`fs-extra`)
+const webpack = require(`webpack`)
+const klawSync = require(`klaw-sync`)
+
+const shebangLoader = require.resolve(`./shebang-loader`)
+const basedir = path.join(__dirname, `..`)
+const modulesDir = path.join(basedir, `node_modules`)
+const isAllowedNativeModule = (mod) => {
+  const modName = mod.path.slice(modulesDir.length + 1).split(path.sep)[0]
+  return ![`fsevents`].includes(modName)
+}
+
+console.log(`Building CLI to a single file`)
+
+// Make sure there are no native modules
+const isBinding = (file) => path.basename(file.path) === `binding.gyp`
+const bindings = klawSync(modulesDir, {
+  nodir: true,
+  filter: isBinding,
+}).filter(isAllowedNativeModule)
+
+/**
+ * N.B.
+ *
+ * We stop building when a native module ("addon") is detected since it has a high-likelihood of causing compatibility issues
+ * (and not just by operating system). The compiled C++ binaries are different on many systems due to a variety of factors
+ * including:
+ * 1. Operating System
+ * 2. CPU architecture
+ * 3. CPU addressing space
+ * 4. (Linuxes) The version of Libc used
+ *
+ * Due to these variations, we simply prevent all native modules from being used in the application. This check prevents them
+ * from sneaking into the packaged code. It should still be possible to use native modules while developing locally, but you
+ * will need to find something else to use in the packaged code. (Sometimes, it's just easier to slap in a native module when you
+ * just want to see something working as a POC in the short-term - that should still be a usable workflow).
+ *
+ * @see https://nodejs.org/api/addons.html
+ * @see https://www.reddit.com/r/node/comments/jcjlav/nodegyp_why_does_it_cause_so_many_problems/
+ */
+if (bindings.length > 0) {
+  console.error(
+    `Native modules ("addons") cannot be used as they cause compatibility errors. You will need to find alternatives, or remove them altogether.`
+  )
+  console.error(`Native module(s) detected:`)
+  bindings.forEach((file) => console.error(file.path))
+  process.exit(1)
+}
+
+// Get path to `open` module
+const openDir = path.dirname(require.resolve(`open`))
+/**
+ * Get path to the xdg-open script packaged within the `open` module
+ *
+ * @see https://unix.stackexchange.com/questions/340531/launch-executable-with-xdg-open
+ */
+const xdgPath = path.join(openDir, `xdg-open`)
+// Copy the xdg-open script to the bin directory
+fse.copy(xdgPath, path.join(basedir, `bin`, `xdg-open`))
+
+const perterter = fse.readFileSync(
+  path.join(basedir, `build-tsconfig.json`),
+  `utf8`
+)
+console.log(`MERSHED: `, perterter)
+
+const tsConfig = JSON.parse(perterter)
+
+// Use the real node __dirname and __filename in order to get Yarn's source
+// files on the user's system
+const nodeOptions = {
+  __filename: false,
+  __dirname: false,
+}
+
+const compiler = webpack({
+  mode: `production`,
+  entry: {
+    "minecraft-asset-reader": path.join(basedir, `bin/entry.js`),
+  },
+  output: {
+    pathinfo: true,
+    filename: `minecraft-asset-reader.js`,
+    path: path.join(basedir, `bin`),
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: [{ loader: `ts-loader`, options: tsConfig }],
+      },
+      {
+        test: /node_modules[/\\](rc)[/\\]/,
+        use: [{ loader: shebangLoader }],
+      },
+    ],
+  },
+  resolve: {
+    extensions: [`.tsx`, `.ts`, `.js`],
+  },
+  plugins: [
+    new webpack.NoEmitOnErrorsPlugin(),
+    new webpack.BannerPlugin({
+      banner: `#!/usr/bin/env node`,
+      raw: true,
+    }),
+    new webpack.DefinePlugin({
+      __MINECRAFT_ASSET_READER_IS_BUNDLED__: JSON.stringify(true),
+
+      // TODO: This a workaround Sanity is using - find out if we actually need to use this
+      // Workaround for rc module console.logging if module.parent does not exist
+      "module.parent": JSON.stringify({}),
+    }),
+  ],
+  target: `node`,
+  node: nodeOptions,
+})
+
+compiler.run((err, stats) => {
+  if (err) {
+    throw err
+  }
+
+  const filtered = stats.compilation.warnings.filter(
+    (warn) =>
+      !warn.origin ||
+      (warn.origin.userRequest.indexOf(`spawn-sync.js`) === -1 &&
+        warn.origin.userRequest.indexOf(`write-file-atomic`) === -1)
+  )
+
+  if (filtered.length > 0) {
+    console.warn(`=== [  Warnings  ]========`)
+    filtered.forEach((warn) => {
+      console.warn(warn.origin ? `\n${warn.origin.userRequest}:` : `\n`)
+      console.warn(`${warn}\n`)
+    })
+    console.warn(`=== [ /Warnings  ]========\n`)
+  }
+
+  if (stats.compilation.errors.length > 0) {
+    console.error(stats.compilation.errors)
+    process.exit(1)
+  }
+
+  // Make the file executable
+  const outputPath = path.join(basedir, `bin`, `minecraft-asset-reader`)
+  fse.chmodSync(outputPath, 0o755)
+
+  // Make paths more dynamic
+  let replacePath = path.normalize(path.join(__dirname, `..`))
+
+  const content = fse.readFileSync(outputPath, `utf8`)
+  const replaceRegex = new RegExp(escapeRegex(`*** ${replacePath}`), `ig`)
+  const normalized = content.replace(replaceRegex, `*** `)
+  fse.writeFileSync(outputPath, normalized, `utf8`)
+
+  console.log(`Done packing.`)
+})
+
+function escapeRegex(string) {
+  return `${string}`.replace(/([?!${}*:()|=^[\]/\\.+])/g, `\\$1`)
+}

--- a/scripts/shebang-loader.js
+++ b/scripts/shebang-loader.js
@@ -1,0 +1,15 @@
+/* eslint-disable space-before-function-paren */
+module.exports = function (content) {
+  if (this.cacheable) {
+    this.cacheable()
+  }
+
+  this.value = content
+  let source = content
+
+  if (typeof source === `string` && /^\s*#!/.test(source)) {
+    source = source.replace(/^\s*#![^\n\r]*[\r\n]/, ``)
+  }
+
+  return source
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1019,7 +1019,7 @@
     core-js-compat "^3.6.2"
     semver "^5.5.0"
 
-"@babel/preset-env@^7.12.1", "@babel/preset-env@^7.13.15", "@babel/preset-env@^7.8.4":
+"@babel/preset-env@^7.12.1", "@babel/preset-env@^7.8.4":
   version "7.14.1"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.14.1.tgz#b55914e2e68885ea03f69600b2d3537e54574a93"
   integrity sha512-0M4yL1l7V4l+j/UHvxcdvNfLB9pPtIooHTbEhgD/6UGyh8Hy3Bm1Mj0buzjDXATCSz3JFibVdnoJZCrlUCanrQ==
@@ -3374,10 +3374,26 @@
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.10.tgz#61cc8469849e5bcdd0c7044122265c39cec10cf4"
   integrity sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ==
 
+"@types/eslint-scope@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.0.tgz#4792816e31119ebd506902a482caec4951fabd86"
+  integrity sha512-O/ql2+rrCUe2W2rs7wMR+GqPRcgB6UiqN5RhrR5xruFlY7l9YLMn0ZkDzjoHLeiFkR8MCQZVudUuuvQ2BLC9Qw==
+  dependencies:
+    "@types/eslint" "*"
+    "@types/estree" "*"
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
+"@types/eslint@*":
+  version "7.2.13"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.13.tgz#e0ca7219ba5ded402062ad6f926d491ebb29dd53"
+  integrity sha512-LKmQCWAlnVHvvXq4oasNUMTJJb2GwSyTY8+1C7OH5ILR8mPLaljv1jxL1bXW3xB3jFbQxTKxJAvI8PyjB09aBg==
+  dependencies:
+    "@types/estree" "*"
+    "@types/json-schema" "*"
 
 "@types/eslint@^7.2.6":
   version "7.2.10"
@@ -3387,7 +3403,7 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*":
+"@types/estree@*", "@types/estree@^0.0.47":
   version "0.0.47"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.47.tgz#d7a51db20f0650efec24cd04994f523d93172ed4"
   integrity sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==
@@ -3894,6 +3910,14 @@
     "@typescript-eslint/types" "4.22.1"
     eslint-visitor-keys "^2.0.0"
 
+"@webassemblyjs/ast@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.0.tgz#a5aa679efdc9e51707a4207139da57920555961f"
+  integrity sha512-kX2W49LWsbthrmIRMbQZuQDhGtjyqXfEmmHyEi4XWnSZtPmxY0+3anPIzsnRb45VH/J55zlOfWvZuY47aJZTJg==
+  dependencies:
+    "@webassemblyjs/helper-numbers" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -3903,15 +3927,30 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
 
+"@webassemblyjs/floating-point-hex-parser@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.0.tgz#34d62052f453cd43101d72eab4966a022587947c"
+  integrity sha512-Q/aVYs/VnPDVYvsCBL/gSgwmfjeCb4LW8+TMrO3cSzJImgv8lxxEPM2JA5jMrivE7LSz3V+PFqtMbls3m1exDA==
+
 "@webassemblyjs/floating-point-hex-parser@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz#3c3d3b271bddfc84deb00f71344438311d52ffb4"
   integrity sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==
 
+"@webassemblyjs/helper-api-error@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.0.tgz#aaea8fb3b923f4aaa9b512ff541b013ffb68d2d4"
+  integrity sha512-baT/va95eXiXb2QflSx95QGT5ClzWpGaa8L7JnJbgzoYeaA27FCvuBXU758l+KXWRndEmUXjP0Q5fibhavIn8w==
+
 "@webassemblyjs/helper-api-error@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz#203f676e333b96c9da2eeab3ccef33c45928b6a2"
   integrity sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==
+
+"@webassemblyjs/helper-buffer@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.0.tgz#d026c25d175e388a7dbda9694e91e743cbe9b642"
+  integrity sha512-u9HPBEl4DS+vA8qLQdEQ6N/eJQ7gT7aNvMIo8AAWvAl/xMrcOSiI2M0MAnMCy3jIFke7bEee/JwdX1nUpCtdyA==
 
 "@webassemblyjs/helper-buffer@1.9.0":
   version "1.9.0"
@@ -3937,10 +3976,34 @@
   dependencies:
     "@webassemblyjs/ast" "1.9.0"
 
+"@webassemblyjs/helper-numbers@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.0.tgz#7ab04172d54e312cc6ea4286d7d9fa27c88cd4f9"
+  integrity sha512-DhRQKelIj01s5IgdsOJMKLppI+4zpmcMQ3XboFPLwCpSNH6Hqo1ritgHgD0nqHeSYqofA6aBN/NmXuGjM1jEfQ==
+  dependencies:
+    "@webassemblyjs/floating-point-hex-parser" "1.11.0"
+    "@webassemblyjs/helper-api-error" "1.11.0"
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/helper-wasm-bytecode@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.0.tgz#85fdcda4129902fe86f81abf7e7236953ec5a4e1"
+  integrity sha512-MbmhvxXExm542tWREgSFnOVo07fDpsBJg3sIl6fSp9xuu75eGz5lz31q7wTLffwL3Za7XNRCMZy210+tnsUSEA==
+
 "@webassemblyjs/helper-wasm-bytecode@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz#4fed8beac9b8c14f8c58b70d124d549dd1fe5790"
   integrity sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==
+
+"@webassemblyjs/helper-wasm-section@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.0.tgz#9ce2cc89300262509c801b4af113d1ca25c1a75b"
+  integrity sha512-3Eb88hcbfY/FCukrg6i3EH8H2UsD7x8Vy47iVJrP967A9JGqgBVL9aH71SETPx1JrGsOUVLo0c7vMCN22ytJew==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-buffer" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+    "@webassemblyjs/wasm-gen" "1.11.0"
 
 "@webassemblyjs/helper-wasm-section@1.9.0":
   version "1.9.0"
@@ -3952,12 +4015,26 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
     "@webassemblyjs/wasm-gen" "1.9.0"
 
+"@webassemblyjs/ieee754@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.0.tgz#46975d583f9828f5d094ac210e219441c4e6f5cf"
+  integrity sha512-KXzOqpcYQwAfeQ6WbF6HXo+0udBNmw0iXDmEK5sFlmQdmND+tr773Ti8/5T/M6Tl/413ArSJErATd8In3B+WBA==
+  dependencies:
+    "@xtuc/ieee754" "^1.2.0"
+
 "@webassemblyjs/ieee754@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz#15c7a0fbaae83fb26143bbacf6d6df1702ad39e4"
   integrity sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==
   dependencies:
     "@xtuc/ieee754" "^1.2.0"
+
+"@webassemblyjs/leb128@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.11.0.tgz#f7353de1df38aa201cba9fb88b43f41f75ff403b"
+  integrity sha512-aqbsHa1mSQAbeeNcl38un6qVY++hh8OpCOzxhixSYgbRfNWcxJNJQwe2rezK9XEcssJbbWIkblaJRwGMS9zp+g==
+  dependencies:
+    "@xtuc/long" "4.2.2"
 
 "@webassemblyjs/leb128@1.9.0":
   version "1.9.0"
@@ -3966,10 +4043,29 @@
   dependencies:
     "@xtuc/long" "4.2.2"
 
+"@webassemblyjs/utf8@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.0.tgz#86e48f959cf49e0e5091f069a709b862f5a2cadf"
+  integrity sha512-A/lclGxH6SpSLSyFowMzO/+aDEPU4hvEiooCMXQPcQFPPJaYcPQNKGOCLUySJsYJ4trbpr+Fs08n4jelkVTGVw==
+
 "@webassemblyjs/utf8@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.9.0.tgz#04d33b636f78e6a6813227e82402f7637b6229ab"
   integrity sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==
+
+"@webassemblyjs/wasm-edit@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.0.tgz#ee4a5c9f677046a210542ae63897094c2027cb78"
+  integrity sha512-JHQ0damXy0G6J9ucyKVXO2j08JVJ2ntkdJlq1UTiUrIgfGMmA7Ik5VdC/L8hBK46kVJgujkBIoMtT8yVr+yVOQ==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-buffer" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+    "@webassemblyjs/helper-wasm-section" "1.11.0"
+    "@webassemblyjs/wasm-gen" "1.11.0"
+    "@webassemblyjs/wasm-opt" "1.11.0"
+    "@webassemblyjs/wasm-parser" "1.11.0"
+    "@webassemblyjs/wast-printer" "1.11.0"
 
 "@webassemblyjs/wasm-edit@1.9.0":
   version "1.9.0"
@@ -3985,6 +4081,17 @@
     "@webassemblyjs/wasm-parser" "1.9.0"
     "@webassemblyjs/wast-printer" "1.9.0"
 
+"@webassemblyjs/wasm-gen@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.0.tgz#3cdb35e70082d42a35166988dda64f24ceb97abe"
+  integrity sha512-BEUv1aj0WptCZ9kIS30th5ILASUnAPEvE3tVMTrItnZRT9tXCLW2LEXT8ezLw59rqPP9klh9LPmpU+WmRQmCPQ==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+    "@webassemblyjs/ieee754" "1.11.0"
+    "@webassemblyjs/leb128" "1.11.0"
+    "@webassemblyjs/utf8" "1.11.0"
+
 "@webassemblyjs/wasm-gen@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz#50bc70ec68ded8e2763b01a1418bf43491a7a49c"
@@ -3996,6 +4103,16 @@
     "@webassemblyjs/leb128" "1.9.0"
     "@webassemblyjs/utf8" "1.9.0"
 
+"@webassemblyjs/wasm-opt@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.0.tgz#1638ae188137f4bb031f568a413cd24d32f92978"
+  integrity sha512-tHUSP5F4ywyh3hZ0+fDQuWxKx3mJiPeFufg+9gwTpYp324mPCQgnuVKwzLTZVqj0duRDovnPaZqDwoyhIO8kYg==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-buffer" "1.11.0"
+    "@webassemblyjs/wasm-gen" "1.11.0"
+    "@webassemblyjs/wasm-parser" "1.11.0"
+
 "@webassemblyjs/wasm-opt@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz#2211181e5b31326443cc8112eb9f0b9028721a61"
@@ -4005,6 +4122,18 @@
     "@webassemblyjs/helper-buffer" "1.9.0"
     "@webassemblyjs/wasm-gen" "1.9.0"
     "@webassemblyjs/wasm-parser" "1.9.0"
+
+"@webassemblyjs/wasm-parser@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.0.tgz#3e680b8830d5b13d1ec86cc42f38f3d4a7700754"
+  integrity sha512-6L285Sgu9gphrcpDXINvm0M9BskznnzJTE7gYkjDbxET28shDqp27wpruyx3C2S/dvEwiigBwLA1cz7lNUi0kw==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-api-error" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+    "@webassemblyjs/ieee754" "1.11.0"
+    "@webassemblyjs/leb128" "1.11.0"
+    "@webassemblyjs/utf8" "1.11.0"
 
 "@webassemblyjs/wasm-parser@1.9.0":
   version "1.9.0"
@@ -4028,6 +4157,14 @@
     "@webassemblyjs/helper-api-error" "1.9.0"
     "@webassemblyjs/helper-code-frame" "1.9.0"
     "@webassemblyjs/helper-fsm" "1.9.0"
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/wast-printer@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.0.tgz#680d1f6a5365d6d401974a8e949e05474e1fab7e"
+  integrity sha512-Fg5OX46pRdTgB7rKIUojkh9vXaVN6sGYCnEiJN1GYkb0RPwShZXp6KTDqmoMdQPKhcroOXh3fEzmkWmCYaKYhQ==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
     "@xtuc/long" "4.2.2"
 
 "@webassemblyjs/wast-printer@1.9.0":
@@ -4133,6 +4270,11 @@ acorn@^8.1.0:
   version "8.2.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.2.4.tgz#caba24b08185c3b56e3168e97d15ed17f4d31fd0"
   integrity sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg==
+
+acorn@^8.2.1:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.3.0.tgz#1193f9b96c4e8232f00b11a9edff81b2c8b98b88"
+  integrity sha512-tqPKHZ5CaBJw0Xmy0ZZvLs1qTV+BNFSyvn77ASXkpBNfIRk8ev26fKrD9iLGwGA9zedPao52GSHzq8lyZG0NUw==
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -6978,6 +7120,14 @@ enhanced-resolve@^4.3.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
+enhanced-resolve@^5.0.0, enhanced-resolve@^5.8.0:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz#15ddc779345cbb73e97c611cd00c01c1e7bf4d8b"
+  integrity sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
 enquirer@^2.3.5, enquirer@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
@@ -7052,6 +7202,11 @@ es-abstract@^1.17.2, es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next.2:
     string.prototype.trimend "^1.0.4"
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.0"
+
+es-module-lexer@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.4.1.tgz#dda8c6a14d8f340a24e34331e0fab0cb50438e0e"
+  integrity sha512-ooYciCUtfw6/d2w56UVeqHPcoCFAiJdz5XOkYpv/Txl1HMUozpXjz/2RIQgqwKdXNDPSF1W7mJCFse3G+HDyAA==
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -7248,6 +7403,14 @@ eslint-plugin-testing-library@^3.9.2:
   dependencies:
     "@typescript-eslint/experimental-utils" "^3.10.1"
 
+eslint-scope@5.1.1, eslint-scope@^5.0.0, eslint-scope@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^4.1.1"
+
 eslint-scope@^3.7.1:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.3.tgz#bb507200d3d17f60247636160b4826284b108535"
@@ -7262,14 +7425,6 @@ eslint-scope@^4.0.0, eslint-scope@^4.0.3:
   integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
   dependencies:
     esrecurse "^4.1.0"
-    estraverse "^4.1.1"
-
-eslint-scope@^5.0.0, eslint-scope@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
-  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
-  dependencies:
-    esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
 eslint-utils@^1.3.1:
@@ -7478,7 +7633,7 @@ eventemitter3@^4.0.0, eventemitter3@^4.0.4:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-events@^3.0.0:
+events@^3.0.0, events@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
@@ -8036,6 +8191,15 @@ from2@^2.1.0, from2@^2.1.1:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
+fs-extra@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
+  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-extra@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
@@ -8334,6 +8498,11 @@ glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@~5.1.0:
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
+
+glob-to-regexp@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
+  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
@@ -10110,6 +10279,15 @@ jest-worker@^26.5.0, jest-worker@^26.6.2:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jest-worker@^27.0.2:
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.0.2.tgz#4ebeb56cef48b3e7514552f80d0d80c0129f0b05"
+  integrity sha512-EoBdilOTTyOgmHXtw/cPc+ZrCA0KJMrkXzkrPGNwLmnvvlN1nj7MPrxpT7m+otSv2e1TLaVffzDnE/LB14zJMg==
+  dependencies:
+    "@types/node" "*"
+    merge-stream "^2.0.0"
+    supports-color "^8.0.0"
+
 jest@26.6.0:
   version "26.6.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-26.6.0.tgz#546b25a1d8c888569dbbe93cae131748086a4a25"
@@ -10301,6 +10479,13 @@ kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -10488,6 +10673,11 @@ loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
+
+loader-runner@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.2.0.tgz#d7022380d66d14c5fb1d496b89864ebcfd478384"
+  integrity sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==
 
 loader-utils@1.2.3:
   version "1.2.3"
@@ -10946,7 +11136,7 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.2:
+micromatch@^4.0.0, micromatch@^4.0.2:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
   integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
@@ -11050,6 +11240,7 @@ min-indent@^1.0.0:
     esm "^3.2.25"
     express "^4.17.1"
     express-paginate "^1.0.2"
+    fs-extra "^10.0.0"
     ink "^3.0.8"
     ink-big-text "^1.2.0"
     ink-divider "^3.0.0"
@@ -12044,7 +12235,7 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
+p-limit@^3.0.2, p-limit@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
@@ -14994,7 +15185,7 @@ sort-keys@^4.0.0:
   dependencies:
     is-plain-obj "^2.0.0"
 
-source-list-map@^2.0.0:
+source-list-map@^2.0.0, source-list-map@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
@@ -15525,6 +15716,13 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+supports-color@^8.0.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
+  dependencies:
+    has-flag "^4.0.0"
+
 supports-hyperlinks@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz#4f77b42488765891774b70c79babd87f9bd594bb"
@@ -15625,6 +15823,11 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
+tapable@^2.1.1, tapable@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
+  integrity sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==
+
 tar@^4, tar@^4.4.12, tar@^4.4.2:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
@@ -15713,6 +15916,18 @@ terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
+terser-webpack-plugin@^5.1.1:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.1.3.tgz#30033e955ca28b55664f1e4b30a1347e61aa23af"
+  integrity sha512-cxGbMqr6+A2hrIB5ehFIF+F/iST5ZOxvOmy9zih9ySbP1C2oEWQSOUS+2SNBTjzx5xLKO4xnod9eywdfq1Nb9A==
+  dependencies:
+    jest-worker "^27.0.2"
+    p-limit "^3.1.0"
+    schema-utils "^3.0.0"
+    serialize-javascript "^5.0.1"
+    source-map "^0.6.1"
+    terser "^5.7.0"
+
 terser@^4.1.2, terser@^4.6.2, terser@^4.6.3:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
@@ -15722,7 +15937,7 @@ terser@^4.1.2, terser@^4.6.2, terser@^4.6.3:
     source-map "~0.6.1"
     source-map-support "~0.5.12"
 
-terser@^5.3.4:
+terser@^5.3.4, terser@^5.7.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.7.0.tgz#a761eeec206bc87b605ab13029876ead938ae693"
   integrity sha512-HP5/9hp2UaZt5fYkuhNBR8YyRcT8juw8+uFbAme53iN9hblvKnLUTKkmwJG6ocWpIKf8UK4DoeWG4ty0J6S6/g==
@@ -15945,6 +16160,16 @@ ts-jest@^26.5.4:
     mkdirp "1.x"
     semver "7.x"
     yargs-parser "20.x"
+
+ts-loader@^9.2.3:
+  version "9.2.3"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.2.3.tgz#dc3b6362a4d4382493cd4f138d345f419656de68"
+  integrity sha512-sEyWiU3JMHBL55CIeC4iqJQadI0U70A5af0kvgbNLHVNz2ACztQg0j/9x10bjjIht8WfFYLKfn4L6tkZ+pu+8Q==
+  dependencies:
+    chalk "^4.1.0"
+    enhanced-resolve "^5.0.0"
+    micromatch "^4.0.0"
+    semver "^7.3.4"
 
 ts-node@^9.1.1:
   version "9.1.1"
@@ -16528,6 +16753,14 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
 
+watchpack@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.2.0.tgz#47d78f5415fe550ecd740f99fe2882323a58b1ce"
+  integrity sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==
+  dependencies:
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.1.2"
+
 wbuf@^1.1.0, wbuf@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
@@ -16640,6 +16873,14 @@ webpack-sources@^1.1.0, webpack-sources@^1.3.0, webpack-sources@^1.4.0, webpack-
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
+webpack-sources@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.3.0.tgz#9ed2de69b25143a4c18847586ad9eccb19278cfa"
+  integrity sha512-WyOdtwSvOML1kbgtXbTDnEW0jkJ7hZr/bDByIwszhWd/4XX1A3XMkrbFMsuH4+/MfLlZCUzlAdg4r7jaGKEIgQ==
+  dependencies:
+    source-list-map "^2.0.1"
+    source-map "^0.6.1"
+
 webpack@4.44.2:
   version "4.44.2"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.44.2.tgz#6bfe2b0af055c8b2d1e90ed2cd9363f841266b72"
@@ -16668,6 +16909,35 @@ webpack@4.44.2:
     terser-webpack-plugin "^1.4.3"
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
+
+webpack@^5.38.1:
+  version "5.38.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.38.1.tgz#5224c7f24c18e729268d3e3bc97240d6e880258e"
+  integrity sha512-OqRmYD1OJbHZph6RUMD93GcCZy4Z4wC0ele4FXyYF0J6AxO1vOSuIlU1hkS/lDlR9CDYBz64MZRmdbdnFFoT2g==
+  dependencies:
+    "@types/eslint-scope" "^3.7.0"
+    "@types/estree" "^0.0.47"
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/wasm-edit" "1.11.0"
+    "@webassemblyjs/wasm-parser" "1.11.0"
+    acorn "^8.2.1"
+    browserslist "^4.14.5"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.8.0"
+    es-module-lexer "^0.4.0"
+    eslint-scope "5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.4"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^4.2.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^3.0.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.1.1"
+    watchpack "^2.2.0"
+    webpack-sources "^2.3.0"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
   version "0.7.4"


### PR DESCRIPTION
# Description

> This PR is still a work in progress

Since we are already leaning hard into the Sanity pipeline, I figure it might be to our benefit to refactor our build workflow to follow that of the Sanity CLI. There isn't really any documentation on how to set it up, so I'm merely reading through [Sanity CLI Package](https://github.com/sanity-io/sanity/tree/next/packages/%40sanity/cli)'s code and setting up a similar pipeline.

**The main thing added in this PR is a build workflow that employs `webpack`, as Sanity does. _We differ from their implementation in that we DO NOT use `babel`, but rather `TypeScript` (e.g., when packing, we use `ts-loader` instead of `babel-loader`)._**

